### PR TITLE
Move participants between rooms if they're too empty or too full

### DIFF
--- a/hosts/embedded.html
+++ b/hosts/embedded.html
@@ -183,7 +183,8 @@
             <span data-bind="if: autoswitchRoom">We'll try a different room in a second (you can turn this off above)</span>
             <span data-bind="ifnot: autoswitchRoom">Try another room for better connection or toggle "auto-switch" above so we take care of this for you!</span>
           </p>
-          <div id="videoboothIframeContainer" style="width: 100%; height: 600px">
+          <div id="videoboothIframeContainer" style="width: 100%; height: 600px; border: 1px solid black">
+            <button data-bind="click: start" style="font-size: 3em; margin: 250px auto 0 auto; display: block; padding: 10px">Start</button>
           </div>
 
           <div style="height: 200px"></div>

--- a/hosts/hosts.js
+++ b/hosts/hosts.js
@@ -129,14 +129,24 @@ function initVideoBoothsModel() {
       }
     }, this);
 
-    this.selectedBoothVideoRoom.subscribe(function() {
+    this.started = ko.observable(false);
+    this.start = function() {
+      _this.started(true);
+      _this.connectToRoom();
+    };
+
+    this.connectToRoom = function() {
+      if (!_this.started()) {
+        return;
+      }
+
       const container = document.querySelector("#videoboothIframeContainer");
       while (container.hasChildNodes()) {
         container.removeChild(container.firstChild);
       }
 
       const options = {
-        roomName: this.selectedBoothVideoRoom(),
+        roomName: _this.selectedBoothVideoRoom(),
         parentNode: container,
         configOverwrite: {
           startWithAudioMuted: true
@@ -162,7 +172,7 @@ function initVideoBoothsModel() {
           ]
         }
       };
-      this.jitsiApi(new JitsiMeetExternalAPI("meet.jit.si", options));
+      _this.jitsiApi(new JitsiMeetExternalAPI("meet.jit.si", options));
       console.log("booth", "new API");
 
       window.setTimeout(function() {
@@ -180,7 +190,8 @@ function initVideoBoothsModel() {
           .jitsiApi()
           .on("participantLeft", _this.updateParticipantsCount.bind(this));
       }, 5000);
-    }, this);
+    };
+    this.selectedBoothVideoRoom.subscribe(this.connectToRoom, this);
 
     this.autoswitchRoom = ko.observable(true);
     this.tooFewParticipants = ko.observable(false);
@@ -245,6 +256,9 @@ function initVideoBoothsModel() {
     this.switchRoom = function() {
       console.log("booth", "Switching");
       _this.autoswitchTimeout(undefined);
+      if (!_this.autoswitchRoom()) {
+        return;
+      }
 
       const tooFew = _this.tooFewParticipants();
       const tooMany = _this.tooManyParticipants();


### PR DESCRIPTION
Right now, I went with 8 people as the upper boundary. The tool will (by default) auto-move to another room after 1 second and display a warning. If you uncheck the "autoswitch" toggle, it will merely suggest you join another room.

It also will only start the video conference once the user presses "START".