### PR TITLE
Events schema allows to add name and url for each moderator and sponsor

### DIFF
--- a/_data/events_gdcr2017/AnnArbor.json
+++ b/_data/events_gdcr2017/AnnArbor.json
@@ -1,18 +1,24 @@
 {
-  "title": "GDCR17 Ann Arbor @ The Forge by Pillar Technology",
-  "url": "http://info.pillartechnology.com/gdcr_pillar_2017_rsvp_glr",
-  "moderators": [
-    "@CuriousAgilist",
-    "@jeevsOnline"
-  ],
-  "location": {
-    "city": "Ann Arbor",
-    "country": "United States of America",
-    "coordinates": {
-      "latitude": 42.279835,
-      "longitude": -83.745728
+    "location": {
+        "city": "Ann Arbor",
+        "coordinates": {
+            "latitude": 42.279835,
+            "longitude": -83.745728
+        },
+        "country": "United States of America",
+        "timezone": "America/Detroit",
+        "utcOffset": -4
     },
-    "utcOffset": -4,
-    "timezone": "America/Detroit"
-  }
+    "moderators": [
+        {
+            "name": "Bob Allen",
+            "url": "https://twitter.com/CuriousAgilist"
+        },
+        {
+            "name": "Jeeva Nadarajah",
+            "url": "https://twitter.com/jeevsOnline"
+        }
+    ],
+    "title": "GDCR17 Ann Arbor @ The Forge by Pillar Technology",
+    "url": "http://info.pillartechnology.com/gdcr_pillar_2017_rsvp_glr"
 }

--- a/_data/events_gdcr2017/Asturias.json
+++ b/_data/events_gdcr2017/Asturias.json
@@ -1,21 +1,30 @@
 {
-  "title": "Asturias Global Day Of Code Retreat 2017, hosted by AsturiasHacking",
-  "url": "https://www.eventbrite.com/e/asturias-global-day-of-code-retreat-2017-tickets-39731055657",
-  "moderators": [
-    "@sergioalvz_",
-    "@dcarral"
-  ],
-  "sponsors": [
-    "@sweetspot"
-  ],
-  "location": {
-    "city": "Gijón",
-    "country": "Spain",
-    "coordinates": {
-      "latitude": 43.5226006,
-      "longitude": -5.6276921
+    "location": {
+        "city": "Gij\u00f3n",
+        "coordinates": {
+            "latitude": 43.5226006,
+            "longitude": -5.6276921
+        },
+        "country": "Spain",
+        "timezone": "Europe/Madrid",
+        "utcOffset": 2
     },
-    "utcOffset": 2,
-    "timezone": "Europe/Madrid"
-  }
+    "moderators": [
+        {
+            "name": "Sergio",
+            "url": "https://twitter.com/codecoolture"
+        },
+        {
+            "name": "Daniel Carral",
+            "url": "https://twitter.com/dcarral"
+        }
+    ],
+    "sponsors": [
+        {
+            "name": "Sweetspot",
+            "url": "https://twitter.com/sweetspot"
+        }
+    ],
+    "title": "Asturias Global Day Of Code Retreat 2017, hosted by AsturiasHacking",
+    "url": "https://www.eventbrite.com/e/asturias-global-day-of-code-retreat-2017-tickets-39731055657"
 }

--- a/_data/events_gdcr2017/Auckland.json
+++ b/_data/events_gdcr2017/Auckland.json
@@ -1,18 +1,24 @@
 {
-  "title": "Global Day of Coderetreat 2017 - Auckland",
-  "url": "https://www.meetup.com/kiwi-code-retreat/events/243504275/",
-  "moderators": [
-    "@mightymuke",
-    "@kiwipom"
-  ],
-  "location": {
-    "city": "Auckland",
-    "country": "New Zealand",
-    "coordinates": {
-      "latitude": -36.8629409,
-      "longitude": 174.7253883
+    "location": {
+        "city": "Auckland",
+        "coordinates": {
+            "latitude": -36.8629409,
+            "longitude": 174.7253883
+        },
+        "country": "New Zealand",
+        "timezone": "Pacific/Auckland",
+        "utcOffset": 12
     },
-    "utcOffset": 12,
-    "timezone": "Pacific/Auckland"
-  }
+    "moderators": [
+        {
+            "name": "Marcus Bristol",
+            "url": "https://twitter.com/mightymuke"
+        },
+        {
+            "name": "Ian Randall",
+            "url": "https://twitter.com/kiwipom"
+        }
+    ],
+    "title": "Global Day of Coderetreat 2017 - Auckland",
+    "url": "https://www.meetup.com/kiwi-code-retreat/events/243504275/"
 }

--- a/_data/events_gdcr2017/Bangkok.json
+++ b/_data/events_gdcr2017/Bangkok.json
@@ -1,17 +1,20 @@
 {
-    "title": "GDCR17 in Bangkok",
-    "url": "https://www.eventpop.me/e/2494",
-    "moderators": [
-      "@roofimon"
-    ],
     "location": {
-      "city": "Bangkok",
-      "country": "Thailand",
-      "coordinates": {
-        "latitude": 13.7301254,
-        "longitude": 100.5660974
-      },
-      "utcOffset": 7,
-      "timezone": "Asia/Bangkok"
-    }
-  }
+        "city": "Bangkok",
+        "coordinates": {
+            "latitude": 13.7301254,
+            "longitude": 100.5660974
+        },
+        "country": "Thailand",
+        "timezone": "Asia/Bangkok",
+        "utcOffset": 7
+    },
+    "moderators": [
+        {
+            "name": "ROOF44",
+            "url": "https://twitter.com/roofimon"
+        }
+    ],
+    "title": "GDCR17 in Bangkok",
+    "url": "https://www.eventpop.me/e/2494"
+}

--- a/_data/events_gdcr2017/Barcelona-Wallapop.json
+++ b/_data/events_gdcr2017/Barcelona-Wallapop.json
@@ -1,17 +1,32 @@
 {
-  "title": "GDCR Barcelona Wallapop",
-  "url": "https://www.meetup.com/es-ES/Wallapop-Engineering/",
-  "moderators": [
-    "@gerardllorente","@jozaez","@eloipoch","@Lascorbe"
-  ],
-  "location": {
-    "city": "Barceloona",
-    "country": "Spain",
-    "coordinates": {
-      "latitude": 41.405919,
-      "longitude": 2.186489
+    "location": {
+        "city": "Barceloona",
+        "coordinates": {
+            "latitude": 41.405919,
+            "longitude": 2.186489
+        },
+        "country": "Spain",
+        "timezone": "Europe/Madrid",
+        "utcOffset": 2
     },
-    "utcOffset": 2,
-    "timezone": "Europe/Madrid"
-  }
+    "moderators": [
+        {
+            "name": "Gerard Llorente",
+            "url": "https://twitter.com/gerardllorente"
+        },
+        {
+            "name": "@jozaez",
+            "url": "https://twitter.com/jozaez"
+        },
+        {
+            "name": "Eloi Poch",
+            "url": "https://twitter.com/eloipoch"
+        },
+        {
+            "name": "Luis Ascorbe",
+            "url": "https://twitter.com/Lascorbe"
+        }
+    ],
+    "title": "GDCR Barcelona Wallapop",
+    "url": "https://www.meetup.com/es-ES/Wallapop-Engineering/"
 }

--- a/_data/events_gdcr2017/Barcelona.json
+++ b/_data/events_gdcr2017/Barcelona.json
@@ -1,20 +1,26 @@
 {
-  "title": "Barcelona Global Day of Coderetreat, facilitated by Codurance",
-  "url": "https://www.meetup.com/Barcelona-Software-Craftsmanship/events/244080253/",
-  "moderators": [
-    "@bberrycarmen"
-  ],
-  "sponsors": [
-    "@codurance_ES"
-  ],
-  "location": {
-    "city": "Barcelona",
-    "country": "Spain",
-    "coordinates": {
-      "latitude": 41.3948976,
-      "longitude": 2.0787274
+    "location": {
+        "city": "Barcelona",
+        "coordinates": {
+            "latitude": 41.3948976,
+            "longitude": 2.0787274
+        },
+        "country": "Spain",
+        "timezone": "Europe/Madrid",
+        "utcOffset": 2
     },
-    "utcOffset": 2,
-    "timezone": "Europe/Madrid"
-  }
+    "moderators": [
+        {
+            "name": "Rachel M. Carmena",
+            "url": "https://twitter.com/bberrycarmen"
+        }
+    ],
+    "sponsors": [
+        {
+            "name": "Codurance Barcelona",
+            "url": "https://twitter.com/codurance_ES"
+        }
+    ],
+    "title": "Barcelona Global Day of Coderetreat, facilitated by Codurance",
+    "url": "https://www.meetup.com/Barcelona-Software-Craftsmanship/events/244080253/"
 }

--- a/_data/events_gdcr2017/Beijing-ThoughtWorks.json
+++ b/_data/events_gdcr2017/Beijing-ThoughtWorks.json
@@ -1,21 +1,32 @@
 {
-  "title": "GDCR 2017 in ThoughtWorks Beijing",
-  "url": "https://gdcr-2017-thoughtworks-beijing.eventbrite.com",
-  "moderators": [
-    "@wubin28",
-    "Jin XU",
-    "Victory Yan WANG",
-    "Minmin QIU",
-    "Ying HE"
-  ],
-  "location": {
-    "city": "Beijing",
-    "country": "China",
-    "coordinates": {
-      "latitude": 39.9375183,
-      "longitude": 116.42804
+    "location": {
+        "city": "Beijing",
+        "coordinates": {
+            "latitude": 39.9375183,
+            "longitude": 116.42804
+        },
+        "country": "China",
+        "timezone": "Asia/Shanghai",
+        "utcOffset": 8
     },
-    "utcOffset": 8,
-    "timezone": "Asia/Shanghai"
-  }
+    "moderators": [
+        {
+            "name": "Ben WU",
+            "url": "https://twitter.com/wubin28"
+        },
+        {
+            "name": "Jin XU"
+        },
+        {
+            "name": "Victory Yan WANG"
+        },
+        {
+            "name": "Minmin QIU"
+        },
+        {
+            "name": "Ying HE"
+        }
+    ],
+    "title": "GDCR 2017 in ThoughtWorks Beijing",
+    "url": "https://gdcr-2017-thoughtworks-beijing.eventbrite.com"
 }

--- a/_data/events_gdcr2017/Beijing.json
+++ b/_data/events_gdcr2017/Beijing.json
@@ -1,14 +1,19 @@
 {
-  "title": "Global Day of Code Retreat 2017 Beijing",
-  "url": "https://www.eventbrite.com/e/global-day-of-code-retreat-2017-beijing-tickets-39273446937",
-  "location": {
-    "city": "Beijing",
-    "country": "China",
-    "coordinates": {
-      "latitude": 40.012426,
-      "longitude": 116.490749
+    "location": {
+        "city": "Beijing",
+        "coordinates": {
+            "latitude": 40.012426,
+            "longitude": 116.490749
+        },
+        "country": "China",
+        "utcOffset": 8
     },
-    "utcOffset": 8
-  },
-  "moderators": ["@YugangB"]
+    "moderators": [
+        {
+            "name": "yugang bai",
+            "url": "https://twitter.com/YugangB"
+        }
+    ],
+    "title": "Global Day of Code Retreat 2017 Beijing",
+    "url": "https://www.eventbrite.com/e/global-day-of-code-retreat-2017-beijing-tickets-39273446937"
 }

--- a/_data/events_gdcr2017/Bellevue.json
+++ b/_data/events_gdcr2017/Bellevue.json
@@ -1,17 +1,20 @@
 {
-  "title": "Global Day of Code Retreat 2017 - Eastside",
-  "url": "https://www.eventbrite.com/e/global-day-of-code-retreat-2017-eastside-tickets-38787852511",
-  "moderators": [
-    "@bm2yogi"
-  ],
-  "location": {
-    "city": "Bellevue",
-    "country": "United States of America",
-    "coordinates": {
-      "latitude": 47.6101,
-      "longitude": -122.2015
+    "location": {
+        "city": "Bellevue",
+        "coordinates": {
+            "latitude": 47.6101,
+            "longitude": -122.2015
+        },
+        "country": "United States of America",
+        "timezone": "America/Los_Angeles",
+        "utcOffset": -7
     },
-    "utcOffset": -7,
-    "timezone": "America/Los_Angeles"
-  }
+    "moderators": [
+        {
+            "name": "Michael Ibarra",
+            "url": "https://twitter.com/bm2yogi"
+        }
+    ],
+    "title": "Global Day of Code Retreat 2017 - Eastside",
+    "url": "https://www.eventbrite.com/e/global-day-of-code-retreat-2017-eastside-tickets-38787852511"
 }

--- a/_data/events_gdcr2017/Belo-Horizonte.json
+++ b/_data/events_gdcr2017/Belo-Horizonte.json
@@ -1,20 +1,32 @@
 {
-  "title": "Global Day of Code Retreat 2017 - Belo Horizonte",
-  "url": "https://www.sympla.com.br/global-day-of-code-retreat---belo-horizonte__211542",
-  "moderators": [
-    "@guifroes",
-    "@guicorsino",
-    "@barralarissa",
-    "@caiquerdrigues"
-  ],
-  "location": {
-    "city": "Belo Horizonte",
-    "country": "Brazil",
-    "coordinates": {
-      "latitude": -19.8157,
-      "longitude": -43.9542
+    "location": {
+        "city": "Belo Horizonte",
+        "coordinates": {
+            "latitude": -19.8157,
+            "longitude": -43.9542
+        },
+        "country": "Brazil",
+        "timezone": "America/Sao_Paulo",
+        "utcOffset": -3
     },
-    "utcOffset": -3,
-    "timezone": "America/Sao_Paulo"
-  }
+    "moderators": [
+        {
+            "name": "Guilherme Froes \u270f\ufe0f",
+            "url": "https://twitter.com/guifroes"
+        },
+        {
+            "name": "Guilherme Corsino",
+            "url": "https://twitter.com/guicorsino"
+        },
+        {
+            "name": "ilustre guria",
+            "url": "https://twitter.com/barralarissa"
+        },
+        {
+            "name": "Caique Rodrigues",
+            "url": "https://twitter.com/caiquerdrigues"
+        }
+    ],
+    "title": "Global Day of Code Retreat 2017 - Belo Horizonte",
+    "url": "https://www.sympla.com.br/global-day-of-code-retreat---belo-horizonte__211542"
 }

--- a/_data/events_gdcr2017/Bend.json
+++ b/_data/events_gdcr2017/Bend.json
@@ -1,15 +1,20 @@
 {
-  "title": "GDCR17 Bend @ OSU Cascades",
-  "url": "https://www.eventbrite.com/e/bend-global-day-of-coderetreat-2017-tickets-38648919960",
-  "location": {
-    "utcOffset": -8,
-    "timezone": "America/Los_Angeles",
-    "city": "Bend",
-    "country": "United States of America",
-    "coordinates": {
-      "latitude": 44.0429237,
-      "longitude": -121.33567239
-    }
-  },
-  "moderators": ["@ybakos"]
+    "location": {
+        "city": "Bend",
+        "coordinates": {
+            "latitude": 44.0429237,
+            "longitude": -121.33567239
+        },
+        "country": "United States of America",
+        "timezone": "America/Los_Angeles",
+        "utcOffset": -8
+    },
+    "moderators": [
+        {
+            "name": "Yong Joseph Bakos",
+            "url": "https://twitter.com/ybakos"
+        }
+    ],
+    "title": "GDCR17 Bend @ OSU Cascades",
+    "url": "https://www.eventbrite.com/e/bend-global-day-of-coderetreat-2017-tickets-38648919960"
 }

--- a/_data/events_gdcr2017/Berlin.json
+++ b/_data/events_gdcr2017/Berlin.json
@@ -1,20 +1,25 @@
 {
-  "title": "GDCR17 Berlin itemis x HTW",
-  "url": "https://www.meetup.com/de-DE/itemis/events/244452768",
-  "moderators": [
-    "Marcel Toussaint"
-  ],
-  "sponsors": [
-    "@itemis"
-  ],
-  "location": {
-    "city": "Berlin",
-    "country": "Germany",
-    "coordinates": {
-      "latitude": 52.4569344,
-      "longitude": 13.524255
+    "location": {
+        "city": "Berlin",
+        "coordinates": {
+            "latitude": 52.4569344,
+            "longitude": 13.524255
+        },
+        "country": "Germany",
+        "timezone": "Europe/Berlin",
+        "utcOffset": 2
     },
-    "utcOffset": 2,
-    "timezone": "Europe/Berlin"
-  }
+    "moderators": [
+        {
+            "name": "Marcel Toussaint"
+        }
+    ],
+    "sponsors": [
+        {
+            "name": "itemis",
+            "url": "https://twitter.com/itemis"
+        }
+    ],
+    "title": "GDCR17 Berlin itemis x HTW",
+    "url": "https://www.meetup.com/de-DE/itemis/events/244452768"
 }

--- a/_data/events_gdcr2017/Berlin_Swk.json
+++ b/_data/events_gdcr2017/Berlin_Swk.json
@@ -1,23 +1,38 @@
 {
-  "title": "GDCR17 Softwerkskammer Berlin",
-  "url": "https://www.eventbrite.com/e/global-day-of-coderetreat-2017-softwerkskammer-berlin-tickets-39627587180",
-  "moderators": [
-    "@alastairs",
-    "@martinklose",
-    "@mrksdck"
-  ],
-  "sponsors": [
-    "@GoEuro",
-    "@Wikimedia"
-  ],
-  "location": {
-    "city": "Berlin",
-    "country": "Germany",
-    "coordinates": {
-      "latitude": 52.5193449,
-      "longitude": 13.4003222
+    "location": {
+        "city": "Berlin",
+        "coordinates": {
+            "latitude": 52.5193449,
+            "longitude": 13.4003222
+        },
+        "country": "Germany",
+        "timezone": "Europe/Berlin",
+        "utcOffset": 1
     },
-    "utcOffset": 1,
-    "timezone": "Europe/Berlin"
-  }
+    "moderators": [
+        {
+            "name": "Alastair Smith",
+            "url": "https://twitter.com/alastairs"
+        },
+        {
+            "name": "Martin Klose",
+            "url": "https://twitter.com/martinklose"
+        },
+        {
+            "name": "Markus Decke",
+            "url": "https://twitter.com/mrksdck"
+        }
+    ],
+    "sponsors": [
+        {
+            "name": "@GoEuro",
+            "url": "https://twitter.com/GoEuro"
+        },
+        {
+            "name": "Wikimedia",
+            "url": "https://twitter.com/Wikimedia"
+        }
+    ],
+    "title": "GDCR17 Softwerkskammer Berlin",
+    "url": "https://www.eventbrite.com/e/global-day-of-coderetreat-2017-softwerkskammer-berlin-tickets-39627587180"
 }

--- a/_data/events_gdcr2017/Bordeaux.json
+++ b/_data/events_gdcr2017/Bordeaux.json
@@ -1,17 +1,20 @@
 {
-  "title": "GDRC17 in Bordeaux",
-  "url": "https://www.meetup.com/software-craftsmanship-bdx/events/242467166",
-  "moderators": [
-    "@lilobase"
-  ],
-  "location": {
-    "city": "Bordeaux",
-    "country": "France",
-    "coordinates": {
-      "latitude": 44.8395063,
-      "longitude": -0.5898097
+    "location": {
+        "city": "Bordeaux",
+        "coordinates": {
+            "latitude": 44.8395063,
+            "longitude": -0.5898097
+        },
+        "country": "France",
+        "timezone": "Europe/Paris",
+        "utcOffset": 2
     },
-    "utcOffset": 2,
-    "timezone": "Europe/Paris"
-  }
+    "moderators": [
+        {
+            "name": "Arnaud LEMAIRE",
+            "url": "https://twitter.com/lilobase"
+        }
+    ],
+    "title": "GDRC17 in Bordeaux",
+    "url": "https://www.meetup.com/software-craftsmanship-bdx/events/242467166"
 }

--- a/_data/events_gdcr2017/Braunschweig.json
+++ b/_data/events_gdcr2017/Braunschweig.json
@@ -1,13 +1,13 @@
 {
-  "title": "HackCamp (with Coderetreat!)",
-  "url": "https://hacktalk.de",
-  "location": {
-    "city": "Braunschweig",
-    "country": "Germany",
-    "coordinates": {
-      "latitude": 52.2784933,
-      "longitude": 10.5226413
+    "location": {
+        "city": "Braunschweig",
+        "coordinates": {
+            "latitude": 52.2784933,
+            "longitude": 10.5226413
+        },
+        "country": "Germany",
+        "timezone": "Europe/Berlin"
     },
-    "timezone": "Europe/Berlin"
-  }
+    "title": "HackCamp (with Coderetreat!)",
+    "url": "https://hacktalk.de"
 }

--- a/_data/events_gdcr2017/Brno.json
+++ b/_data/events_gdcr2017/Brno.json
@@ -1,15 +1,25 @@
 {
-  "title": "Global Day of CodeRetreat 2017 in Brno",
-  "url": "https://www.solarwindsmeetup.com/event/gdcr-2017/",
-  "moderators": ["Vladimir Kopso", "Jakub Fojtl", "Evzen Zelinka"],
-  "location": {
-    "city": "Brno",
-    "country": "Czech Republic",
-    "coordinates": {
-      "latitude": 49.1903765,
-      "longitude": 16.618112
+    "location": {
+        "city": "Brno",
+        "coordinates": {
+            "latitude": 49.1903765,
+            "longitude": 16.618112
+        },
+        "country": "Czech Republic",
+        "timezone": "Europe/Vienna",
+        "utcOffset": 2
     },
-    "utcOffset": 2,
-    "timezone": "Europe/Vienna"
-  }
+    "moderators": [
+        {
+            "name": "Vladimir Kopso"
+        },
+        {
+            "name": "Jakub Fojtl"
+        },
+        {
+            "name": "Evzen Zelinka"
+        }
+    ],
+    "title": "Global Day of CodeRetreat 2017 in Brno",
+    "url": "https://www.solarwindsmeetup.com/event/gdcr-2017/"
 }

--- a/_data/events_gdcr2017/Brussels.json
+++ b/_data/events_gdcr2017/Brussels.json
@@ -1,17 +1,20 @@
 {
-  "title": "GDCR17 in Brussels",
-  "url": "https://www.eventbrite.ca/e/global-day-code-retreat-in-brussels-tickets-39328399301",
-  "moderators": [
-    "@_toch"
-  ],
-  "location": {
-    "city": "Brussles",
-    "country": "Belgium",
-    "coordinates": {
-      "latitude": 50.8550625,
-      "longitude": 4.3053506
+    "location": {
+        "city": "Brussles",
+        "coordinates": {
+            "latitude": 50.8550625,
+            "longitude": 4.3053506
+        },
+        "country": "Belgium",
+        "timezone": "Europe/Luxembourg",
+        "utcOffset": 2
     },
-    "utcOffset": 2,
-    "timezone": "Europe/Luxembourg"
-  }
+    "moderators": [
+        {
+            "name": "Christophe",
+            "url": "https://twitter.com/_toch"
+        }
+    ],
+    "title": "GDCR17 in Brussels",
+    "url": "https://www.eventbrite.ca/e/global-day-code-retreat-in-brussels-tickets-39328399301"
 }

--- a/_data/events_gdcr2017/Bucharest.json
+++ b/_data/events_gdcr2017/Bucharest.json
@@ -1,18 +1,22 @@
 {
-  "title": "Code Retreat Day @Cegeka",
-  "url": "https://www.cegeka.com/ro/en/events/coderetreat-at-cegeka",
-  "moderators": [
-    "Bogdan Iancu",
-    "Cristina Darie"
-  ],
-  "location": {
-    "city": "București",
-    "country": "Romania",
-    "coordinates": {
-      "latitude": 44.4545737,
-      "longitude": 26.0815525
+    "location": {
+        "city": "Bucure\u0219ti",
+        "coordinates": {
+            "latitude": 44.4545737,
+            "longitude": 26.0815525
+        },
+        "country": "Romania",
+        "timezone": "Europe/Bucharest",
+        "utcOffset": 3
     },
-    "utcOffset": 3,
-    "timezone": "Europe/Bucharest"
-  }
+    "moderators": [
+        {
+            "name": "Bogdan Iancu"
+        },
+        {
+            "name": "Cristina Darie"
+        }
+    ],
+    "title": "Code Retreat Day @Cegeka",
+    "url": "https://www.cegeka.com/ro/en/events/coderetreat-at-cegeka"
 }

--- a/_data/events_gdcr2017/Bucharest2.json
+++ b/_data/events_gdcr2017/Bucharest2.json
@@ -1,17 +1,20 @@
 {
-  "title": "Global Day of Coderetreat @ MozaicWorks",
-  "url": "https://www.meetup.com/The-Bucharest-Agile-Software-Meetup-Group/events/243846221/",
-  "moderators": [
-    "@AlinPandichi"
-  ],
-  "location": {
-    "city": "București",
-    "country": "Romania",
-    "coordinates": {
-      "latitude": 44.4545737,
-      "longitude": 26.0815525
+    "location": {
+        "city": "Bucure\u0219ti",
+        "coordinates": {
+            "latitude": 44.4545737,
+            "longitude": 26.0815525
+        },
+        "country": "Romania",
+        "timezone": "Europe/Bucharest",
+        "utcOffset": 3
     },
-    "utcOffset": 3,
-    "timezone": "Europe/Bucharest"
-  }
+    "moderators": [
+        {
+            "name": "Alin Pandichi",
+            "url": "https://twitter.com/AlinPandichi"
+        }
+    ],
+    "title": "Global Day of Coderetreat @ MozaicWorks",
+    "url": "https://www.meetup.com/The-Bucharest-Agile-Software-Meetup-Group/events/243846221/"
 }

--- a/_data/events_gdcr2017/Budapest.json
+++ b/_data/events_gdcr2017/Budapest.json
@@ -1,17 +1,20 @@
 {
-  "title": "GDCR17 Budapest",
-  "url": "https://www.meetup.com/Coderetreat-Budapest/",
-  "moderators": [
-    "@devillmeister"
-  ],
-  "location": {
-    "city": "Budapest",
-    "country": "Hungary",
-    "coordinates": {
-      "latitude": 47.485497,
-      "longitude": 19.074604
+    "location": {
+        "city": "Budapest",
+        "coordinates": {
+            "latitude": 47.485497,
+            "longitude": 19.074604
+        },
+        "country": "Hungary",
+        "timezone": "Europe/Berlin",
+        "utcOffset": 2
     },
-    "utcOffset": 2,
-    "timezone": "Europe/Berlin"
-  }
+    "moderators": [
+        {
+            "name": "@devillmeister",
+            "url": "https://twitter.com/devillmeister"
+        }
+    ],
+    "title": "GDCR17 Budapest",
+    "url": "https://www.meetup.com/Coderetreat-Budapest/"
 }

--- a/_data/events_gdcr2017/BuenosAires.json
+++ b/_data/events_gdcr2017/BuenosAires.json
@@ -1,22 +1,34 @@
 {
-  "title": "Buenos Aires Global Day of Code Retreat 2017",
-  "url": "https://www.eventbrite.com/e/buenos-aires-global-day-of-code-retreat-2017-tickets-37863898941",
-  "moderators": [
-    "@ferscorpi",
-    "@pasku1",
-    "@gonzalojg"
-  ],
-  "sponsors": [
-    "@etermax"
-  ],
-  "location": {
-    "city": "Buenos Aires",
-    "country": "Argentina",
-    "coordinates": {
-      "latitude": -34.604624,
-      "longitude": -58.4154677
+    "location": {
+        "city": "Buenos Aires",
+        "coordinates": {
+            "latitude": -34.604624,
+            "longitude": -58.4154677
+        },
+        "country": "Argentina",
+        "timezone": "America/Buenos_Aires",
+        "utcOffset": -3
     },
-    "utcOffset": -3,
-    "timezone": "America/Buenos_Aires"
-  }
+    "moderators": [
+        {
+            "name": "Fernando Scorpiniti",
+            "url": "https://twitter.com/ferscorpi"
+        },
+        {
+            "name": "Guillermo Pascual",
+            "url": "https://twitter.com/pasku1"
+        },
+        {
+            "name": "Gonzalo Garcia",
+            "url": "https://twitter.com/gonzalojg"
+        }
+    ],
+    "sponsors": [
+        {
+            "name": "Etermax",
+            "url": "https://twitter.com/etermax"
+        }
+    ],
+    "title": "Buenos Aires Global Day of Code Retreat 2017",
+    "url": "https://www.eventbrite.com/e/buenos-aires-global-day-of-code-retreat-2017-tickets-37863898941"
 }

--- a/_data/events_gdcr2017/Calgary.json
+++ b/_data/events_gdcr2017/Calgary.json
@@ -1,13 +1,16 @@
 {
-  "title": "GDCR17 in Calgary",
-  "url": "https://www.meetup.com/Calgary-Agile-Methods-User-Group/events/244066406/",
-  "moderators": [
-    "@ttrungvo"
-  ],
-  "location": {
-    "city": "Calgary",
-    "country": "Canada",
-    "utcOffset": -6,
-    "timezone": "America/Edmonton"
-  }
+    "location": {
+        "city": "Calgary",
+        "country": "Canada",
+        "timezone": "America/Edmonton",
+        "utcOffset": -6
+    },
+    "moderators": [
+        {
+            "name": "Trung Vo",
+            "url": "https://twitter.com/ttrungvo"
+        }
+    ],
+    "title": "GDCR17 in Calgary",
+    "url": "https://www.meetup.com/Calgary-Agile-Methods-User-Group/events/244066406/"
 }

--- a/_data/events_gdcr2017/Cambridge-UK.json
+++ b/_data/events_gdcr2017/Cambridge-UK.json
@@ -1,15 +1,24 @@
 {
-  "title": "GDCR17 in Cambridge, UK",
-  "url": "https://www.meetup.com/Cambridge-Software-Crafters/events/244355943/",
-  "moderators": [
-    "@SamirTalwar",
-    "@alextercete",
-    "@AmelieCornelis"
-  ],
-  "location": {
-    "city": "Cambridge",
-    "country": "United Kingdom",
-    "utcOffset": 1,
-    "timezone": "Europe/London"
-  }
+    "location": {
+        "city": "Cambridge",
+        "country": "United Kingdom",
+        "timezone": "Europe/London",
+        "utcOffset": 1
+    },
+    "moderators": [
+        {
+            "name": "not here",
+            "url": "https://twitter.com/SamirTalwar"
+        },
+        {
+            "name": "Alex Tercete",
+            "url": "https://twitter.com/alextercete"
+        },
+        {
+            "name": "Am\u00e9lie Corn\u00e9lis",
+            "url": "https://twitter.com/AmelieCornelis"
+        }
+    ],
+    "title": "GDCR17 in Cambridge, UK",
+    "url": "https://www.meetup.com/Cambridge-Software-Crafters/events/244355943/"
 }

--- a/_data/events_gdcr2017/Cambridge.json
+++ b/_data/events_gdcr2017/Cambridge.json
@@ -1,17 +1,20 @@
 {
-  "title": "GDCR17 in Cambridge, MA @ Pivotal Labs ",
-  "url": "https://www.eventbrite.com/e/global-day-of-code-retreat-cambridge-tickets-37433620968",
-  "moderators": [
-    "@amandamunoz"
-  ],
-  "location": {
-    "city": "Cambridge",
-    "country": "United States of America",
-    "coordinates": {
-      "latitude": 42.3626831,
-      "longitude": -71.087541
+    "location": {
+        "city": "Cambridge",
+        "coordinates": {
+            "latitude": 42.3626831,
+            "longitude": -71.087541
+        },
+        "country": "United States of America",
+        "timezone": "America/New_York",
+        "utcOffset": -4
     },
-    "utcOffset": -4,
-    "timezone": "America/New_York"
-  }
+    "moderators": [
+        {
+            "name": "amanda mu\u00f1oz",
+            "url": "https://twitter.com/amandamunoz"
+        }
+    ],
+    "title": "GDCR17 in Cambridge, MA @ Pivotal Labs ",
+    "url": "https://www.eventbrite.com/e/global-day-of-code-retreat-cambridge-tickets-37433620968"
 }

--- a/_data/events_gdcr2017/Casablanca.json
+++ b/_data/events_gdcr2017/Casablanca.json
@@ -1,17 +1,20 @@
 {
-  "title": "GDCR 17 in Casablanca",
-  "url": "https://www.meetup.com/fr-FR/Software-Crafts-wo-manship-Casablanca/events/245002855/",
-  "moderators": [
-    "@A_ElArbi"
-  ],
-  "location": {
-    "city": "Casablanca",
-    "country": "Morocco",
-	"coordinates": {
-      "latitude": 33.5696389,
-      "longitude": -7.6451054
+    "location": {
+        "city": "Casablanca",
+        "coordinates": {
+            "latitude": 33.5696389,
+            "longitude": -7.6451054
+        },
+        "country": "Morocco",
+        "timezone": "Africa/Casablanca",
+        "utcOffset": 1
     },
-    "utcOffset": 1,
-    "timezone": "Africa/Casablanca"
-  }
+    "moderators": [
+        {
+            "name": "Aboussoror",
+            "url": "https://twitter.com/A_ElArbi"
+        }
+    ],
+    "title": "GDCR 17 in Casablanca",
+    "url": "https://www.meetup.com/fr-FR/Software-Crafts-wo-manship-Casablanca/events/245002855/"
 }

--- a/_data/events_gdcr2017/Charlottetown.json
+++ b/_data/events_gdcr2017/Charlottetown.json
@@ -1,18 +1,24 @@
 {
-  "title": "GDCR 17 in Charlottetown",
-  "url": "https://www.meetup.com/PEI-Developers/events/244684325/",
-  "moderators": [
-    "@evanepio",
-    "@ncphi"
-  ],
-  "location": {
-    "city": "Charlottetown",
-    "country": "Canada",
-    "coordinates": {
-      "latitude": 46.231994,
-      "longitude": -63.1273027
+    "location": {
+        "city": "Charlottetown",
+        "coordinates": {
+            "latitude": 46.231994,
+            "longitude": -63.1273027
+        },
+        "country": "Canada",
+        "timezone": "America/Halifax",
+        "utcOffset": -3
     },
-    "utcOffset": -3,
-    "timezone": "America/Halifax"
-  }
+    "moderators": [
+        {
+            "name": "Evan Porter",
+            "url": "https://twitter.com/evanepio"
+        },
+        {
+            "name": "nolan",
+            "url": "https://twitter.com/ncphi"
+        }
+    ],
+    "title": "GDCR 17 in Charlottetown",
+    "url": "https://www.meetup.com/PEI-Developers/events/244684325/"
 }

--- a/_data/events_gdcr2017/Cluj.json
+++ b/_data/events_gdcr2017/Cluj.json
@@ -1,19 +1,28 @@
 {
-  "title": "GDCR17 in Cluj",
-  "url": "https://www.facebook.com/gdcr.cluj/",
-  "moderators": [
-    "@horea_hopartean",
-    "@florincoros",
-    "@sergiudamian"
-  ],
-  "location": {
-    "city": "Cluj-Napoca",
-    "country": "Romania",
-    "coordinates": {
-      "latitude": 46.7729781,
-      "longitude": 23.589513200000056
+    "location": {
+        "city": "Cluj-Napoca",
+        "coordinates": {
+            "latitude": 46.7729781,
+            "longitude": 23.589513200000056
+        },
+        "country": "Romania",
+        "timezone": "Europe/Bucharest",
+        "utcOffset": 3
     },
-    "utcOffset": 3,
-    "timezone": "Europe/Bucharest"
-  }
+    "moderators": [
+        {
+            "name": "Horea Hopartean",
+            "url": "https://twitter.com/horea_hopartean"
+        },
+        {
+            "name": "Florin Coros",
+            "url": "https://twitter.com/florincoros"
+        },
+        {
+            "name": "Sergiu Damian",
+            "url": "https://twitter.com/sergiudamian"
+        }
+    ],
+    "title": "GDCR17 in Cluj",
+    "url": "https://www.facebook.com/gdcr.cluj/"
 }

--- a/_data/events_gdcr2017/Columbus.json
+++ b/_data/events_gdcr2017/Columbus.json
@@ -1,17 +1,19 @@
 {
-  "title": "GDCR17 Columbus @ The Forge by Pillar Technology",
-  "url": "http://info.pillartechnology.com/gdcr_pillar_2017_rsvp_ovr",
-  "moderators": [
-    "Mark Holtman (@mholtman)"
-  ],
-  "location": {
-    "city": "Columbus",
-    "country": "United States of America",
-    "coordinates": {
-      "latitude": 39.9746425,
-      "longitude": -82.9998932
+    "location": {
+        "city": "Columbus",
+        "coordinates": {
+            "latitude": 39.9746425,
+            "longitude": -82.9998932
+        },
+        "country": "United States of America",
+        "timezone": "America/New_York",
+        "utcOffset": -4
     },
-    "utcOffset": -4,
-    "timezone": "America/New_York"
-  }
+    "moderators": [
+        {
+            "name": "Mark Holtman (@mholtman)"
+        }
+    ],
+    "title": "GDCR17 Columbus @ The Forge by Pillar Technology",
+    "url": "http://info.pillartechnology.com/gdcr_pillar_2017_rsvp_ovr"
 }

--- a/_data/events_gdcr2017/Corrientes.json
+++ b/_data/events_gdcr2017/Corrientes.json
@@ -1,22 +1,34 @@
 {
-  "title": "Corrientes Global Day of Code Retreat 2017",
-  "url": "https://www.eventbrite.com.ar/e/corrientes-global-day-of-code-retreat-2017-tickets-39924023830",
-  "moderators": [
-    "@matiasmasca",
-    "@fernandezja",
-    "@Sk8Porti"
-  ],
-  "sponsors": [
-    "@desarrollosnea"
-  ],
-  "location": {
-    "city": "Corrientes",
-    "country": "Argentina",
-    "coordinates": {
-      "latitude": -27.4615947,
-      "longitude": -58.8312107
+    "location": {
+        "city": "Corrientes",
+        "coordinates": {
+            "latitude": -27.4615947,
+            "longitude": -58.8312107
+        },
+        "country": "Argentina",
+        "timezone": "America/Buenos_Aires",
+        "utcOffset": -3
     },
-    "utcOffset": -3,
-    "timezone": "America/Buenos_Aires"
-  }
+    "moderators": [
+        {
+            "name": "Mat\u00edas Mascazzini",
+            "url": "https://twitter.com/matiasmasca"
+        },
+        {
+            "name": "Jose A. Fernandez",
+            "url": "https://twitter.com/fernandezja"
+        },
+        {
+            "name": "Augusto Portillo",
+            "url": "https://twitter.com/Sk8Porti"
+        }
+    ],
+    "sponsors": [
+        {
+            "name": "Desarrollos NEA",
+            "url": "https://twitter.com/desarrollosnea"
+        }
+    ],
+    "title": "Corrientes Global Day of Code Retreat 2017",
+    "url": "https://www.eventbrite.com.ar/e/corrientes-global-day-of-code-retreat-2017-tickets-39924023830"
 }

--- a/_data/events_gdcr2017/Curitiba.json
+++ b/_data/events_gdcr2017/Curitiba.json
@@ -1,16 +1,20 @@
 {
-  "title": "GDCR17 in Curitiba",
-  "url": "http://www.dainf.ct.utfpr.edu.br/~adolfo/dokuwiki/doku.php?id=2017:global_day_of_coderetreat_2017",
-  "moderators": [
-    "@adolfont"
-  ],
-  "location": {
-    "city": "Curitiba",
-    "country": "Brazil",
-    "coordinates": {
-      "latitude": -25.4284,
-      "longitude": -49.2689362    },
-    "utcOffset": -3,
-    "timezone": "America/Sao_Paulo"
-  }
+    "location": {
+        "city": "Curitiba",
+        "coordinates": {
+            "latitude": -25.4284,
+            "longitude": -49.2689362
+        },
+        "country": "Brazil",
+        "timezone": "America/Sao_Paulo",
+        "utcOffset": -3
+    },
+    "moderators": [
+        {
+            "name": "Adolfo Neto",
+            "url": "https://twitter.com/adolfont"
+        }
+    ],
+    "title": "GDCR17 in Curitiba",
+    "url": "http://www.dainf.ct.utfpr.edu.br/~adolfo/dokuwiki/doku.php?id=2017:global_day_of_coderetreat_2017"
 }

--- a/_data/events_gdcr2017/Denver.json
+++ b/_data/events_gdcr2017/Denver.json
@@ -1,14 +1,19 @@
 {
-  "title": "Global Day of Code Retreat 2017 Denver",
-  "url": "https://www.eventbrite.com/e/global-day-of-code-retreat-2017-denver-tickets-37865069442",
-  "location": {
-    "city": "Denver",
-    "country": "United States of America",
-    "coordinates": {
-      "latitude": 39.7489555,
-      "longitude": -105.0016706
+    "location": {
+        "city": "Denver",
+        "coordinates": {
+            "latitude": 39.7489555,
+            "longitude": -105.0016706
+        },
+        "country": "United States of America",
+        "utcOffset": -6
     },
-    "utcOffset": -6
-  },
-  "moderators": ["@kimdhendrick"]
+    "moderators": [
+        {
+            "name": "Kim D Hendrick",
+            "url": "https://twitter.com/kimdhendrick"
+        }
+    ],
+    "title": "Global Day of Code Retreat 2017 Denver",
+    "url": "https://www.eventbrite.com/e/global-day-of-code-retreat-2017-denver-tickets-37865069442"
 }

--- a/_data/events_gdcr2017/Des Moines.json
+++ b/_data/events_gdcr2017/Des Moines.json
@@ -1,17 +1,20 @@
 {
-    "title": "GDCR17 Des Moines @ The Forge by Pillar Technology",
-    "url": "http://info.pillartechnology.com/gdcr_pillar_2017_rsvp_ihr",
-    "moderators": [
-        "Nathan Schlehlein (nschlehlein@pillartechnology.com)"
-    ],
     "location": {
         "city": "Des Moines",
-        "country": "United States of America",
         "coordinates": {
             "latitude": 41.584268,
             "longitude": -93.63547
         },
-        "utcOffset": -5,
-        "timezone": "America/Chicago"
-    }
+        "country": "United States of America",
+        "timezone": "America/Chicago",
+        "utcOffset": -5
+    },
+    "moderators": [
+        {
+            "name": "Nathan Schlehlein",
+            "url": "mailto:nschlehlein@pillartechnology.com"
+        }
+    ],
+    "title": "GDCR17 Des Moines @ The Forge by Pillar Technology",
+    "url": "http://info.pillartechnology.com/gdcr_pillar_2017_rsvp_ihr"
 }

--- a/_data/events_gdcr2017/Dortmund.json
+++ b/_data/events_gdcr2017/Dortmund.json
@@ -1,20 +1,32 @@
 {
-  "title": "Global Day of Coderetreat - Softwerkskammer Ruhr Area",
-  "url": "http://meetu.ps/3cP7p4",
-  "moderators": [
-    "@georgberky",
-    "@SandraParsick",
-    "@ThomasTraude",
-    "@Kiview"
-  ],
-  "location": {
-    "city": "Dortmund",
-    "country": "Germany",
-    "coordinates": {
-      "latitude": 51.492667,
-      "longitude": 7.404709
+    "location": {
+        "city": "Dortmund",
+        "coordinates": {
+            "latitude": 51.492667,
+            "longitude": 7.404709
+        },
+        "country": "Germany",
+        "timezone": "Europe/Berlin",
+        "utcOffset": 2
     },
-    "utcOffset": 2,
-    "timezone": "Europe/Berlin"
-  }
+    "moderators": [
+        {
+            "name": "Georg Berky",
+            "url": "https://twitter.com/georgberky"
+        },
+        {
+            "name": "Sandra Parsick",
+            "url": "https://twitter.com/SandraParsick"
+        },
+        {
+            "name": "Thomas Traude",
+            "url": "https://twitter.com/ThomasTraude"
+        },
+        {
+            "name": "Kevin Wittek",
+            "url": "https://twitter.com/Kiview"
+        }
+    ],
+    "title": "Global Day of Coderetreat - Softwerkskammer Ruhr Area",
+    "url": "http://meetu.ps/3cP7p4"
 }

--- a/_data/events_gdcr2017/Durban.json
+++ b/_data/events_gdcr2017/Durban.json
@@ -1,17 +1,20 @@
 {
-  "title": "GDCR17 in Durban",
-  "url": "https://www.meetup.com/coderetreat/events/244078875/",
-  "moderators": [
-    "@brendonpaginate"
-  ],
-  "location": {
-    "city": "Durban",
-    "country": "South Africa",
-    "coordinates": {
-      "latitude": -29.8202824,
-      "longitude": 31.025753
+    "location": {
+        "city": "Durban",
+        "coordinates": {
+            "latitude": -29.8202824,
+            "longitude": 31.025753
+        },
+        "country": "South Africa",
+        "timezone": "Africa/Johannesburg",
+        "utcOffset": 2
     },
-    "utcOffset": 2,
-    "timezone": "Africa/Johannesburg"
-  }
+    "moderators": [
+        {
+            "name": "Brendon Page",
+            "url": "https://twitter.com/brendonpaginate"
+        }
+    ],
+    "title": "GDCR17 in Durban",
+    "url": "https://www.meetup.com/coderetreat/events/244078875/"
 }

--- a/_data/events_gdcr2017/EPAMHyderabad.json
+++ b/_data/events_gdcr2017/EPAMHyderabad.json
@@ -1,17 +1,20 @@
 {
-  "title": "EPAM Hyderabad GDCR 17",
-  "url": "http://events.epam.com/secure-events/m4MC9AEOcjQDaHPb7rpsyfUk",
-  "moderators": [
-    "@rohit_elan"
-  ],
-  "location": {
-    "city": "Hyderabad",
-    "country": "India",
-    "coordinates": {
-      "latitude": 17.4228313,
-      "longitude": 78.4210918
+    "location": {
+        "city": "Hyderabad",
+        "coordinates": {
+            "latitude": 17.4228313,
+            "longitude": 78.4210918
+        },
+        "country": "India",
+        "timezone": "Asia/Kolkata",
+        "utcOffset": 5.5
     },
-    "utcOffset": 5.5,
-    "timezone": "Asia/Kolkata"
-  }
+    "moderators": [
+        {
+            "name": "(Rohit \u0930\u094b\u0939\u093f\u0924 \u0935\u0948\u0926\u094d\u092f)",
+            "url": "https://twitter.com/rohit_elan"
+        }
+    ],
+    "title": "EPAM Hyderabad GDCR 17",
+    "url": "http://events.epam.com/secure-events/m4MC9AEOcjQDaHPb7rpsyfUk"
 }

--- a/_data/events_gdcr2017/Edmonton.json
+++ b/_data/events_gdcr2017/Edmonton.json
@@ -1,17 +1,19 @@
 {
-  "title": "GDCR17 in Edmonton",
-  "url": "https://www.eventbrite.ca/e/global-day-of-coderetreat-edmonton-tickets-37315716312",
-  "moderators": [
-    "Aaron"
-  ],
-  "location": {
-    "city": "Edmonton",
-    "country": "Canada",
-    "coordinates": {
-      "latitude": 53.541405,
-      "longitude": -113.4951316
+    "location": {
+        "city": "Edmonton",
+        "coordinates": {
+            "latitude": 53.541405,
+            "longitude": -113.4951316
+        },
+        "country": "Canada",
+        "timezone": "America/Edmonton",
+        "utcOffset": -6
     },
-    "utcOffset": -6,
-    "timezone": "America/Edmonton"
-  }
+    "moderators": [
+        {
+            "name": "Aaron"
+        }
+    ],
+    "title": "GDCR17 in Edmonton",
+    "url": "https://www.eventbrite.ca/e/global-day-of-coderetreat-edmonton-tickets-37315716312"
 }

--- a/_data/events_gdcr2017/Erlangen.json
+++ b/_data/events_gdcr2017/Erlangen.json
@@ -1,14 +1,26 @@
 {
-  "title": "GDCR17 @MATHEMA in Erlangen",
-  "url": "https://www.mathema.de/veranstaltungen",
-  "location": {
-    "timezone": "Europe/Berlin",
-    "city": "Erlangen",
-    "country": "Germany",
-    "coordinates": {
-      "latitude": 49.5950784,
-      "longitude": 11.0190458
-    }
-  },
-  "moderators": ["@timothep", "@ThomasABertz", "NikoMay"]
+    "location": {
+        "city": "Erlangen",
+        "coordinates": {
+            "latitude": 49.5950784,
+            "longitude": 11.0190458
+        },
+        "country": "Germany",
+        "timezone": "Europe/Berlin"
+    },
+    "moderators": [
+        {
+            "name": "Tim Bourguignon",
+            "url": "https://twitter.com/timothep"
+        },
+        {
+            "name": "Thomas Bertz",
+            "url": "https://twitter.com/ThomasABertz"
+        },
+        {
+            "name": "NikoMay"
+        }
+    ],
+    "title": "GDCR17 @MATHEMA in Erlangen",
+    "url": "https://www.mathema.de/veranstaltungen"
 }

--- a/_data/events_gdcr2017/Essen.json
+++ b/_data/events_gdcr2017/Essen.json
@@ -1,18 +1,22 @@
 {
-  "title": "Global Day of Coderetreat 2017 Essen",
-  "url": "https://www.meetup.com/de-DE/JUG-Essen/events/244337551/",
-  "moderators": [
-    "Halil Hancioglu",
-    "Birgit Kratz"
-  ],
-  "location": {
-    "city": "Essen",
-    "country": "Germany",
-    "coordinates": {
-      "latitude": 51.4556366,
-      "longitude": 6.9976476
+    "location": {
+        "city": "Essen",
+        "coordinates": {
+            "latitude": 51.4556366,
+            "longitude": 6.9976476
+        },
+        "country": "Germany",
+        "timezone": "Europe/Berlin",
+        "utcOffset": 2
     },
-    "utcOffset": 2,
-    "timezone": "Europe/Berlin"
-  }
+    "moderators": [
+        {
+            "name": "Halil Hancioglu"
+        },
+        {
+            "name": "Birgit Kratz"
+        }
+    ],
+    "title": "Global Day of Coderetreat 2017 Essen",
+    "url": "https://www.meetup.com/de-DE/JUG-Essen/events/244337551/"
 }

--- a/_data/events_gdcr2017/Fortaleza.json
+++ b/_data/events_gdcr2017/Fortaleza.json
@@ -1,21 +1,30 @@
 {
-  "title": "GDCR17 em Fortaleza",
-  "url": "https://goo.gl/FT5KzX",
-  "moderators": [
-    "@pbenety",
-    "@lobinhojr"
-  ],
-  "sponsors": [
-  	"@iatlantico"
-  ],
-  "location": {
-    "city": "Fortaleza",
-    "country": "Brasil",
-    "coordinates": {
-      "latitude": -3.7652304,
-      "longitude": -38.4797354
+    "location": {
+        "city": "Fortaleza",
+        "coordinates": {
+            "latitude": -3.7652304,
+            "longitude": -38.4797354
+        },
+        "country": "Brasil",
+        "timezone": "America/Fortaleza",
+        "utcOffset": -3
     },
-    "utcOffset": -3,
-    "timezone": "America/Fortaleza"
-  }
+    "moderators": [
+        {
+            "name": "Paulo Benety",
+            "url": "https://twitter.com/pbenety"
+        },
+        {
+            "name": "Lobo Junior",
+            "url": "https://twitter.com/lobinhojr"
+        }
+    ],
+    "sponsors": [
+        {
+            "name": "Instituto Atl\u00e2ntico",
+            "url": "https://twitter.com/iatlantico"
+        }
+    ],
+    "title": "GDCR17 em Fortaleza",
+    "url": "https://goo.gl/FT5KzX"
 }

--- a/_data/events_gdcr2017/Fulda.json
+++ b/_data/events_gdcr2017/Fulda.json
@@ -1,19 +1,22 @@
 {
-  "title": "Global Day of Coderetreat 2017 Fulda",
-  "url": "https://beta.doodle.com/poll/eng47rzzqzchdsnc",
-  "moderators": [
-    "Thomas Papendieck",
-    "Dr. Martine Herpers (@computera42)"
-  ],
-  "location": {
-    "city": "Fulda",
-    "country": "Germany",
-    "coordinates": {
-      "latitude": 50.56522,
-      "longitude": 9.68457
+    "location": {
+        "city": "Fulda",
+        "coordinates": {
+            "latitude": 50.56522,
+            "longitude": 9.68457
+        },
+        "country": "Germany",
+        "timezone": "Europe/Berlin",
+        "utcOffset": 2
     },
-    "utcOffset": 2,
-    "timezone": "Europe/Berlin"
-  }
+    "moderators": [
+        {
+            "name": "Thomas Papendieck"
+        },
+        {
+            "name": "Dr. Martine Herpers (@computera42)"
+        }
+    ],
+    "title": "Global Day of Coderetreat 2017 Fulda",
+    "url": "https://beta.doodle.com/poll/eng47rzzqzchdsnc"
 }
-

--- a/_data/events_gdcr2017/Gdansk.json
+++ b/_data/events_gdcr2017/Gdansk.json
@@ -1,19 +1,28 @@
 {
-  "title": "GDCR17 in Gdansk",
-  "url": "https://events.epam.com/events/global-day-of-coderetreat-gdansk-2017",
-  "moderators": [
-    "@michalgruca",
-    "@pamakuch",
-    "@radekzielinski"
-  ],
-  "location": {
-    "city": "Gdansk",
-    "country": "Poland",
-    "coordinates": {
-      "latitude": 54.403014,
-      "longitude": 18.571636
+    "location": {
+        "city": "Gdansk",
+        "coordinates": {
+            "latitude": 54.403014,
+            "longitude": 18.571636
+        },
+        "country": "Poland",
+        "timezone": "Europe/Warsaw",
+        "utcOffset": 2
     },
-    "utcOffset": 2,
-    "timezone": "Europe/Warsaw"
-  }
+    "moderators": [
+        {
+            "name": "Micha\u0142 Gruca",
+            "url": "https://twitter.com/michalgruca"
+        },
+        {
+            "name": "Patryk Makuch",
+            "url": "https://twitter.com/pamakuch"
+        },
+        {
+            "name": "Radoslaw Zielinski",
+            "url": "https://twitter.com/radekzielinski"
+        }
+    ],
+    "title": "GDCR17 in Gdansk",
+    "url": "https://events.epam.com/events/global-day-of-coderetreat-gdansk-2017"
 }

--- a/_data/events_gdcr2017/Gent.json
+++ b/_data/events_gdcr2017/Gent.json
@@ -1,18 +1,24 @@
 {
-  "title": "Global Day of Code Retreat - Gent 2017",
-  "url": "https://www.meetup.com/socratesbe/events/244350997/",
-  "moderators": [
-    "@talboomerik",
-    "@koenmetsu"
-  ],
-  "location": {
-    "city": "Gent",
-    "country": "Belgium",
-    "coordinates": {
-      "latitude": 51.0169,
-      "longitude": 3.7343
+    "location": {
+        "city": "Gent",
+        "coordinates": {
+            "latitude": 51.0169,
+            "longitude": 3.7343
+        },
+        "country": "Belgium",
+        "timezone": "Europe/Brussels",
+        "utcOffset": 2
     },
-    "utcOffset": 2,
-    "timezone": "Europe/Brussels"
-  }
+    "moderators": [
+        {
+            "name": "Erik Talboom",
+            "url": "https://twitter.com/talboomerik"
+        },
+        {
+            "name": "Koen Metsu",
+            "url": "https://twitter.com/koenmetsu"
+        }
+    ],
+    "title": "Global Day of Code Retreat - Gent 2017",
+    "url": "https://www.meetup.com/socratesbe/events/244350997/"
 }

--- a/_data/events_gdcr2017/Ghana.json
+++ b/_data/events_gdcr2017/Ghana.json
@@ -1,17 +1,20 @@
 {
-"title": "GDCR17 Ghana",
-  "url": "https://www.eventbrite.com/e/global-day-of-coderetreat-tickets-39180826908",
-  "moderators": [
-    "@eddy_mens"
-  ],
-  "location": {
-    "city": "Accra",
-    "country": "Ghana",
-    "coordinates": {
-      "latitude": 5.6452373,
-      "longitude": -0.1514363
+    "location": {
+        "city": "Accra",
+        "coordinates": {
+            "latitude": 5.6452373,
+            "longitude": -0.1514363
+        },
+        "country": "Ghana",
+        "timezone": "Europe/London",
+        "utcOffset": 1
     },
-    "utcOffset": 1,
-    "timezone": "Europe/London"
-  }
+    "moderators": [
+        {
+            "name": "@eddy_mens",
+            "url": "https://twitter.com/eddy_mens"
+        }
+    ],
+    "title": "GDCR17 Ghana",
+    "url": "https://www.eventbrite.com/e/global-day-of-coderetreat-tickets-39180826908"
 }

--- a/_data/events_gdcr2017/Haarlem.json
+++ b/_data/events_gdcr2017/Haarlem.json
@@ -1,17 +1,20 @@
 {
-  "title": "GDCR17 in Haarlem, NL",
-  "url": "https://www.meetup.com/Haarlem-Software-Development-Meetup/events/243324861/",
-  "moderators": [
-    "@mcbeelen"
-  ],
-  "location": {
-    "city": "Haarlem",
-    "country": "Netherlands",
-    "coordinates": {
-      "latitude": 52.3815753,
-      "longitude": 4.6405239
+    "location": {
+        "city": "Haarlem",
+        "coordinates": {
+            "latitude": 52.3815753,
+            "longitude": 4.6405239
+        },
+        "country": "Netherlands",
+        "timezone": "Europe/Amsterdam",
+        "utcOffset": 2
     },
-    "utcOffset": 2,
-    "timezone": "Europe/Amsterdam"
-  }
+    "moderators": [
+        {
+            "name": "Marco Beelen",
+            "url": "https://twitter.com/mcbeelen"
+        }
+    ],
+    "title": "GDCR17 in Haarlem, NL",
+    "url": "https://www.meetup.com/Haarlem-Software-Development-Meetup/events/243324861/"
 }

--- a/_data/events_gdcr2017/Hamburg.json
+++ b/_data/events_gdcr2017/Hamburg.json
@@ -1,19 +1,28 @@
 {
-  "title": "GDCR17 in Hamburg, Germany",
-  "url": "https://www.meetup.com/de-DE/sokahh/events/239067827/",
-  "moderators": [
-    "@sokahh",
-    "@mreinhardt",
-    "@SvenBunge"
-  ],
-  "location": {
-    "city": "Hamburg",
-    "country": "Germany",
-    "coordinates": {
-      "latitude": 53.5567,
-      "longitude": 9.9085
+    "location": {
+        "city": "Hamburg",
+        "coordinates": {
+            "latitude": 53.5567,
+            "longitude": 9.9085
+        },
+        "country": "Germany",
+        "timezone": "Europe/Berlin",
+        "utcOffset": 2
     },
-    "utcOffset": 2,
-   "timezone":"Europe/Berlin"
-  }
+    "moderators": [
+        {
+            "name": "Kalym4x",
+            "url": "https://twitter.com/sokahh"
+        },
+        {
+            "name": "Martin Reinhardt",
+            "url": "https://twitter.com/mreinhardt"
+        },
+        {
+            "name": "Sven Bunge",
+            "url": "https://twitter.com/SvenBunge"
+        }
+    ],
+    "title": "GDCR17 in Hamburg, Germany",
+    "url": "https://www.meetup.com/de-DE/sokahh/events/239067827/"
 }

--- a/_data/events_gdcr2017/Hanoi.json
+++ b/_data/events_gdcr2017/Hanoi.json
@@ -1,17 +1,19 @@
 {
-  "title": "GDCR17 at CodeGym",
-  "url": "https://hangouts.google.com/hangouts/_/agilead.vn/globaldayofcodetreat2017",
-  "moderators": [
-    "Khoa, Nhat, Son"
-  ],
-  "location": {
-    "city": "Hanoi",
-    "country": "Vietnam",
-    "coordinates": {
-      "latitude": 21.0338718,
-      "longitude": 105.7632193
+    "location": {
+        "city": "Hanoi",
+        "coordinates": {
+            "latitude": 21.0338718,
+            "longitude": 105.7632193
+        },
+        "country": "Vietnam",
+        "timezone": "Asia/Saigon",
+        "utcOffset": 7
     },
-    "utcOffset": 7,
-    "timezone": "Asia/Saigon"
-  }
+    "moderators": [
+        {
+            "name": "Khoa, Nhat, Son"
+        }
+    ],
+    "title": "GDCR17 at CodeGym",
+    "url": "https://hangouts.google.com/hangouts/_/agilead.vn/globaldayofcodetreat2017"
 }

--- a/_data/events_gdcr2017/Heilbronn.json
+++ b/_data/events_gdcr2017/Heilbronn.json
@@ -1,18 +1,24 @@
 {
-  "title": "Global Day of Coderetreat in Heilbronn",
-  "url": "https://www.eventbrite.de/e/global-day-of-coderetreat-2017-tickets-38500347576",
-  "moderators": [
-    "@thaberkern",
-    "@silent_fred"
-  ],
-  "location": {
-    "city": "Heilbronn",
-    "country": "Germany",
-    "coordinates": {
-      "latitude": 49.1700534,
-      "longitude": 9.2221827
+    "location": {
+        "city": "Heilbronn",
+        "coordinates": {
+            "latitude": 49.1700534,
+            "longitude": 9.2221827
+        },
+        "country": "Germany",
+        "timezone": "Europe/Berlin",
+        "utcOffset": 2
     },
-    "utcOffset": 2,
-    "timezone": "Europe/Berlin"
-  }
+    "moderators": [
+        {
+            "name": "@thaberkern",
+            "url": "https://twitter.com/thaberkern"
+        },
+        {
+            "name": "Michael K\u00fchweg",
+            "url": "https://twitter.com/silent_fred"
+        }
+    ],
+    "title": "Global Day of Coderetreat in Heilbronn",
+    "url": "https://www.eventbrite.de/e/global-day-of-coderetreat-2017-tickets-38500347576"
 }

--- a/_data/events_gdcr2017/Hyderabad-JUG.json
+++ b/_data/events_gdcr2017/Hyderabad-JUG.json
@@ -1,17 +1,20 @@
 {
-  "title": "JUG Hyderabad GDCR 17",
-  "url": "https://www.meetup.com/jughyderabad/events/244680395",
-  "moderators": [
-    "@prbuddha"
-  ],
-  "location": {
-    "city": "Hyderabad",
-    "country": "India",
-    "coordinates": {
-      "latitude": 17.4276289,
-      "longitude": 78.3313518
+    "location": {
+        "city": "Hyderabad",
+        "coordinates": {
+            "latitude": 17.4276289,
+            "longitude": 78.3313518
+        },
+        "country": "India",
+        "timezone": "Asia/Kolkata",
+        "utcOffset": 5.5
     },
-    "utcOffset": 5.5,
-    "timezone": "Asia/Kolkata"
-  }
+    "moderators": [
+        {
+            "name": "Buddha Jyothiprasad",
+            "url": "https://twitter.com/prbuddha"
+        }
+    ],
+    "title": "JUG Hyderabad GDCR 17",
+    "url": "https://www.meetup.com/jughyderabad/events/244680395"
 }

--- a/_data/events_gdcr2017/Hyderabad.json
+++ b/_data/events_gdcr2017/Hyderabad.json
@@ -1,18 +1,24 @@
 {
-  "title": "CDCR17 in Hyderabad",
-  "url": "https://www.meetup.com/preview/hyscala/events/244254659",
-  "moderators": [
-    "@rajmahendra",
-    "@purijatin7"
-  ],
-  "location": {
-    "city": "Hyderabad",
-    "country": "India",
-    "coordinates": {
-      "latitude": 17.4201755,
-      "longitude": 78.3373567
+    "location": {
+        "city": "Hyderabad",
+        "coordinates": {
+            "latitude": 17.4201755,
+            "longitude": 78.3373567
+        },
+        "country": "India",
+        "timezone": "Asia/Kolkata",
+        "utcOffset": 5.5
     },
-    "utcOffset": 5.5,
-    "timezone": "Asia/Kolkata"
-  }
+    "moderators": [
+        {
+            "name": "Mahendra.Raj.Bhandar",
+            "url": "https://twitter.com/rajmahendra"
+        },
+        {
+            "name": "Jatin Puri",
+            "url": "https://twitter.com/purijatin7"
+        }
+    ],
+    "title": "CDCR17 in Hyderabad",
+    "url": "https://www.meetup.com/preview/hyscala/events/244254659"
 }

--- a/_data/events_gdcr2017/Johannesburg.json
+++ b/_data/events_gdcr2017/Johannesburg.json
@@ -1,19 +1,28 @@
 {
-  "title": "GDCR17 in Johannesburg",
-  "url": "https://www.meetup.com/coderetreat/events/244874423/",
-  "moderators": [
-    "@drivenalliance",
-    "@garethstep",
-    "@jancowol"
-  ],
-  "location": {
-    "city": "Johannesburg",
-    "country": "South Africa",
-    "utcOffset": 2,
-    "timezone": "Africa/Johannesburg",
-    "coordinates": {
-      "latitude": -26.1855441,
-      "longitude": 28.0169193
-    }
-  }
+    "location": {
+        "city": "Johannesburg",
+        "coordinates": {
+            "latitude": -26.1855441,
+            "longitude": 28.0169193
+        },
+        "country": "South Africa",
+        "timezone": "Africa/Johannesburg",
+        "utcOffset": 2
+    },
+    "moderators": [
+        {
+            "name": "Driven",
+            "url": "https://twitter.com/drivenalliance"
+        },
+        {
+            "name": "Gareth Stephenson",
+            "url": "https://twitter.com/garethstep"
+        },
+        {
+            "name": "Janco Wolmarans",
+            "url": "https://twitter.com/jancowol"
+        }
+    ],
+    "title": "GDCR17 in Johannesburg",
+    "url": "https://www.meetup.com/coderetreat/events/244874423/"
 }

--- a/_data/events_gdcr2017/Karlsruhe.json
+++ b/_data/events_gdcr2017/Karlsruhe.json
@@ -1,15 +1,24 @@
 {
-  "title": "GDCR17 @fiducia_gad in Karlsruhe",
-  "url": "https://www.softwerkskammer.org/activities/ka-gdcr-17/",
-  "location": {
-    "utcOffset": 2,
-    "timezone": "Europe/Berlin",
-    "city": "Karlsruhe",
-    "country": "Germany",
-    "coordinates": {
-      "latitude": 48.994277,
-      "longitude": 8.446993
-    }
-  },
-  "moderators": ["@ursmetz", "@chr1shaefn3r"]
+    "location": {
+        "city": "Karlsruhe",
+        "coordinates": {
+            "latitude": 48.994277,
+            "longitude": 8.446993
+        },
+        "country": "Germany",
+        "timezone": "Europe/Berlin",
+        "utcOffset": 2
+    },
+    "moderators": [
+        {
+            "name": "Urs Metz",
+            "url": "https://twitter.com/ursmetz"
+        },
+        {
+            "name": "Christoph H\u00e4fner",
+            "url": "https://twitter.com/chr1shaefn3r"
+        }
+    ],
+    "title": "GDCR17 @fiducia_gad in Karlsruhe",
+    "url": "https://www.softwerkskammer.org/activities/ka-gdcr-17/"
 }

--- a/_data/events_gdcr2017/LasPalmasGC.json
+++ b/_data/events_gdcr2017/LasPalmasGC.json
@@ -1,19 +1,28 @@
 {
-  "title": "Global Day of CodeRetreat GC 2017",
-  "url": "https://www.meetup.com/es-ES/SPEGC-Sociedad-de-Promocion-Economica-de-Gran-Canaria/events/244753003/",
-  "moderators": [
-    "@GodoyJonay",
-    "@yonayCL",
-    "@Antonio_sanglez"
-  ],
-  "location": {
-    "city": "Las Palmas",
-    "country": "Spain",
-    "coordinates": {
-      "latitude": 28.106227345525383,
-      "longitude": -15.446037813491788
+    "location": {
+        "city": "Las Palmas",
+        "coordinates": {
+            "latitude": 28.106227345525383,
+            "longitude": -15.446037813491788
+        },
+        "country": "Spain",
+        "timezone": "Atlantic/Canary",
+        "utcOffset": 1
     },
-    "utcOffset": 1,
-    "timezone": "Atlantic/Canary"
-  }
+    "moderators": [
+        {
+            "name": "Jonay Godoy",
+            "url": "https://twitter.com/GodoyJonay"
+        },
+        {
+            "name": "Yonay Cabrera L\u00f3pez",
+            "url": "https://twitter.com/yonayCL"
+        },
+        {
+            "name": "Antonio S\u00e1nchez",
+            "url": "https://twitter.com/Antonio_sanglez"
+        }
+    ],
+    "title": "Global Day of CodeRetreat GC 2017",
+    "url": "https://www.meetup.com/es-ES/SPEGC-Sociedad-de-Promocion-Economica-de-Gran-Canaria/events/244753003/"
 }

--- a/_data/events_gdcr2017/Leipzig.json
+++ b/_data/events_gdcr2017/Leipzig.json
@@ -1,19 +1,27 @@
 {
-  "title": "GDCR 2017 in Leipzig",
-  "url": "https://www.meetup.com/de-DE/Softwerkskammer-Leipzig/events/243267001/",
-  "moderators": [
-    "@florianpilz",
-    "@maik_toepfer",
-    "Christoph Weißenborn"
-  ],
-  "location": {
-    "city": "Leipzig",
-    "country": "Germany",
-    "coordinates": {
-      "latitude": 51.3202439,
-      "longitude": 12.3353715
+    "location": {
+        "city": "Leipzig",
+        "coordinates": {
+            "latitude": 51.3202439,
+            "longitude": 12.3353715
+        },
+        "country": "Germany",
+        "timezone": "Europe/Berlin",
+        "utcOffset": 2
     },
-    "utcOffset": 2,
-    "timezone": "Europe/Berlin"
-  }
+    "moderators": [
+        {
+            "name": "Florian Pilz",
+            "url": "https://twitter.com/florianpilz"
+        },
+        {
+            "name": "Maik Toepfer",
+            "url": "https://twitter.com/maik_toepfer"
+        },
+        {
+            "name": "Christoph Wei\u00dfenborn"
+        }
+    ],
+    "title": "GDCR 2017 in Leipzig",
+    "url": "https://www.meetup.com/de-DE/Softwerkskammer-Leipzig/events/243267001/"
 }

--- a/_data/events_gdcr2017/Leuven.json
+++ b/_data/events_gdcr2017/Leuven.json
@@ -1,18 +1,24 @@
 {
-  "title": "Global Day of Code Retreat - Leuven 2017",
-  "url": "https://www.meetup.com/socratesbe/events/244350891/",
-  "moderators": [
-    "@TimSchraepen",
-    "@verhoevenv"
-  ],
-  "location": {
-    "city": "Leuven",
-    "country": "Belgium",
-    "coordinates": {
-      "latitude": 50.8468,
-      "longitude": 4.7294
+    "location": {
+        "city": "Leuven",
+        "coordinates": {
+            "latitude": 50.8468,
+            "longitude": 4.7294
+        },
+        "country": "Belgium",
+        "timezone": "Europe/Brussels",
+        "utcOffset": 2
     },
-    "utcOffset": 2,
-    "timezone": "Europe/Brussels"
-  }
+    "moderators": [
+        {
+            "name": "Tim Schraepen",
+            "url": "https://twitter.com/TimSchraepen"
+        },
+        {
+            "name": "Vincent Verhoeven",
+            "url": "https://twitter.com/verhoevenv"
+        }
+    ],
+    "title": "Global Day of Code Retreat - Leuven 2017",
+    "url": "https://www.meetup.com/socratesbe/events/244350891/"
 }

--- a/_data/events_gdcr2017/Lisbon.json
+++ b/_data/events_gdcr2017/Lisbon.json
@@ -1,22 +1,34 @@
 {
-  "title": "Coderetreat 2017 in Lisbon",
-  "url": "https://www.meetup.com/expert-talks-portugal/events/244654861/",
-  "moderators": [
-    "@i3r41n",
-    "@jivagoalves",
-    "@nfma"
-  ],
-  "sponsors": [
-    "@EE_Portugal"
-  ],
-  "location": {
-    "city": "Lisbon",
-    "country": "Portugal",
-    "coordinates": {
-      "latitude": 38.7697814,
-      "longitude": -9.1001402
+    "location": {
+        "city": "Lisbon",
+        "coordinates": {
+            "latitude": 38.7697814,
+            "longitude": -9.1001402
+        },
+        "country": "Portugal",
+        "timezone": "Europe/Lisbon",
+        "utcOffset": 1
     },
-    "utcOffset": 1,
-    "timezone": "Europe/Lisbon"
-  }
+    "moderators": [
+        {
+            "name": "Bruno Santos",
+            "url": "https://twitter.com/i3r41n"
+        },
+        {
+            "name": "Jivago Alves",
+            "url": "https://twitter.com/jivagoalves"
+        },
+        {
+            "name": "Nuno Marques",
+            "url": "https://twitter.com/nfma"
+        }
+    ],
+    "sponsors": [
+        {
+            "name": "EqualExpertsPortugal",
+            "url": "https://twitter.com/EE_Portugal"
+        }
+    ],
+    "title": "Coderetreat 2017 in Lisbon",
+    "url": "https://www.meetup.com/expert-talks-portugal/events/244654861/"
 }

--- a/_data/events_gdcr2017/Lodz.json
+++ b/_data/events_gdcr2017/Lodz.json
@@ -1,17 +1,20 @@
 {
-  "title": "GDCR17 LODZ",
-  "url": "https://www.meetup.com/Java-User-Group-Lodz/events/243444033/",
-  "moderators": [
-    "@PawelWlodarski"
-  ],
-  "location": {
-    "city": "Lodz",
-    "country": "Poland",
-    "coordinates": {
-      "latitude": 51.774,
-      "longitude": 19.4675113
+    "location": {
+        "city": "Lodz",
+        "coordinates": {
+            "latitude": 51.774,
+            "longitude": 19.4675113
+        },
+        "country": "Poland",
+        "timezone": "Europe/Warsaw",
+        "utcOffset": 2
     },
-    "utcOffset": 2,
-    "timezone": "Europe/Warsaw"
-  }
+    "moderators": [
+        {
+            "name": "Pawe\u0142 W\u0142odarski",
+            "url": "https://twitter.com/PawelWlodarski"
+        }
+    ],
+    "title": "GDCR17 LODZ",
+    "url": "https://www.meetup.com/Java-User-Group-Lodz/events/243444033/"
 }

--- a/_data/events_gdcr2017/Logrono.json
+++ b/_data/events_gdcr2017/Logrono.json
@@ -1,17 +1,20 @@
 {
-  "title": "GDCR17 in Logroño",
-  "url": "http://riojadotnet.com/eventos/global-day-of-coderetreat-2017",
-  "moderators": [
-    "@luissagasta"
-  ],
-  "location": {
-    "city": "Logroño",
-    "country": "Spain",
-    "coordinates": {
-      "latitude": 42.4607989,
-      "longitude": -2.4182367
+    "location": {
+        "city": "Logro\u00f1o",
+        "coordinates": {
+            "latitude": 42.4607989,
+            "longitude": -2.4182367
+        },
+        "country": "Spain",
+        "timezone": "Europe/Madrid",
+        "utcOffset": 2
     },
-    "utcOffset": 2,
-    "timezone": "Europe/Madrid"
-  }
+    "moderators": [
+        {
+            "name": "Luis Sagasta",
+            "url": "https://twitter.com/luissagasta"
+        }
+    ],
+    "title": "GDCR17 in Logro\u00f1o",
+    "url": "http://riojadotnet.com/eventos/global-day-of-coderetreat-2017"
 }

--- a/_data/events_gdcr2017/London-Codurance.json
+++ b/_data/events_gdcr2017/London-Codurance.json
@@ -1,19 +1,28 @@
 {
-  "title": "Global Day of Coderetreat @ Codurance",
-  "url": "https://www.meetup.com/london-software-craftsmanship/events/244321442/",
-  "moderators": [
-    "@RobertFirek",
-    "@CarlosMChica",
-    "@yefoakira"
-  ],
-  "location": {
-    "city": "London",
-    "country": "United Kingdom",
-    "coordinates": {
-      "latitude": 51.5238487,
-      "longitude": -0.102661
+    "location": {
+        "city": "London",
+        "coordinates": {
+            "latitude": 51.5238487,
+            "longitude": -0.102661
+        },
+        "country": "United Kingdom",
+        "timezone": "Europe/London",
+        "utcOffset": 1
     },
-    "utcOffset": 1,
-    "timezone": "Europe/London"
-  }
+    "moderators": [
+        {
+            "name": "Robert Firek",
+            "url": "https://twitter.com/RobertFirek"
+        },
+        {
+            "name": "Carlos Morera",
+            "url": "https://twitter.com/CarlosMChica"
+        },
+        {
+            "name": "Jorge Gueorguiev",
+            "url": "https://twitter.com/yefoakira"
+        }
+    ],
+    "title": "Global Day of Coderetreat @ Codurance",
+    "url": "https://www.meetup.com/london-software-craftsmanship/events/244321442/"
 }

--- a/_data/events_gdcr2017/London-Pivotal.json
+++ b/_data/events_gdcr2017/London-Pivotal.json
@@ -1,20 +1,32 @@
 {
-  "title": "GDCR 17 @ Pivotal London",
-  "url": "https://www.eventbrite.com/e/global-day-of-code-retreat-pivotal-tickets-37119002937",
-  "moderators": [
-    "@deniseyu21",
-    "@jamesjoshuahill",
-    "@chewymeister",
-    "@KaraMarck"
-  ],
-  "location": {
-    "city": "London",
-    "country": "United Kingdom",
-    "coordinates": {
-      "latitude": 51.526239,
-      "longitude": -0.088862
+    "location": {
+        "city": "London",
+        "coordinates": {
+            "latitude": 51.526239,
+            "longitude": -0.088862
+        },
+        "country": "United Kingdom",
+        "timezone": "Europe/London",
+        "utcOffset": 1
     },
-    "utcOffset": 1,
-    "timezone": "Europe/London"
-  }
+    "moderators": [
+        {
+            "name": "Denise Yu",
+            "url": "https://twitter.com/deniseyu21"
+        },
+        {
+            "name": "Josh Hill",
+            "url": "https://twitter.com/jamesjoshuahill"
+        },
+        {
+            "name": "Jonathan QW Tsang",
+            "url": "https://twitter.com/chewymeister"
+        },
+        {
+            "name": "Kara de la Marck",
+            "url": "https://twitter.com/KaraMarck"
+        }
+    ],
+    "title": "GDCR 17 @ Pivotal London",
+    "url": "https://www.eventbrite.com/e/global-day-of-code-retreat-pivotal-tickets-37119002937"
 }

--- a/_data/events_gdcr2017/London-Spektrix.json
+++ b/_data/events_gdcr2017/London-Spektrix.json
@@ -1,18 +1,24 @@
 {
-  "title": "GDCR17 at Spektrix",
-  "url": "https://www.eventbrite.co.uk/e/gdcr2017-spektrix-tickets-38543450498",
-  "moderators": [
-    "@dannojb",
-    "@mimmozzo"
-  ],
-  "location": {
-    "city": "London",
-    "country": "United Kingdom",
-    "coordinates": {
-      "latitude": 51.5127679,
-      "longitude": -0.1056135
+    "location": {
+        "city": "London",
+        "coordinates": {
+            "latitude": 51.5127679,
+            "longitude": -0.1056135
+        },
+        "country": "United Kingdom",
+        "timezone": "Europe/London",
+        "utcOffset": 1
     },
-    "utcOffset": 1,
-    "timezone": "Europe/London"
-  }
+    "moderators": [
+        {
+            "name": "Dan Bass",
+            "url": "https://twitter.com/dannojb"
+        },
+        {
+            "name": "Domenico Musto",
+            "url": "https://twitter.com/mimmozzo"
+        }
+    ],
+    "title": "GDCR17 at Spektrix",
+    "url": "https://www.eventbrite.co.uk/e/gdcr2017-spektrix-tickets-38543450498"
 }

--- a/_data/events_gdcr2017/London-TAB.json
+++ b/_data/events_gdcr2017/London-TAB.json
@@ -1,17 +1,20 @@
 {
-  "title": "Global Day of Coderetreat @ TAB",
-  "url": "https://www.eventbrite.co.uk/e/global-day-of-code-retreat-tab-london-tickets-39248331817",
-  "moderators": [
-    "@WillRochaThomas"
-  ],
-  "location": {
-    "city": "London",
-    "country": "United Kingdom",
-    "coordinates": {
-      "latitude": 51.5318879,
-      "longitude": -0.1207121
+    "location": {
+        "city": "London",
+        "coordinates": {
+            "latitude": 51.5318879,
+            "longitude": -0.1207121
+        },
+        "country": "United Kingdom",
+        "timezone": "Europe/London",
+        "utcOffset": 1
     },
-    "utcOffset": 1,
-    "timezone": "Europe/London"
-  }
+    "moderators": [
+        {
+            "name": "Will Rocha-Thomas",
+            "url": "https://twitter.com/WillRochaThomas"
+        }
+    ],
+    "title": "Global Day of Coderetreat @ TAB",
+    "url": "https://www.eventbrite.co.uk/e/global-day-of-code-retreat-tab-london-tickets-39248331817"
 }

--- a/_data/events_gdcr2017/London-ThoghtWorks.json
+++ b/_data/events_gdcr2017/London-ThoghtWorks.json
@@ -1,18 +1,23 @@
 {
-  "title": "GDCR 17 @ ThoughtWorks London",
-  "url": "https://www.eventbrite.co.uk/e/gdcr-17-at-thoughtworks-london-tickets-39116170519",
-  "moderators": [
-    "@obol8381",
-    "Gergő Takács"
-  ],
-  "location": {
-    "city": "London",
-    "country": "United Kingdom",
-    "coordinates": {
-      "latitude": 51.513109,
-      "longitude": -0.133617
+    "location": {
+        "city": "London",
+        "coordinates": {
+            "latitude": 51.513109,
+            "longitude": -0.133617
+        },
+        "country": "United Kingdom",
+        "timezone": "Europe/London",
+        "utcOffset": 1
     },
-    "utcOffset": 1,
-    "timezone": "Europe/London"
-  }
+    "moderators": [
+        {
+            "name": "Tak\u00e1cs Gerg\u0151",
+            "url": "https://twitter.com/obol8381"
+        },
+        {
+            "name": "Gerg\u0151 Tak\u00e1cs"
+        }
+    ],
+    "title": "GDCR 17 @ ThoughtWorks London",
+    "url": "https://www.eventbrite.co.uk/e/gdcr-17-at-thoughtworks-london-tickets-39116170519"
 }

--- a/_data/events_gdcr2017/London.json
+++ b/_data/events_gdcr2017/London.json
@@ -1,19 +1,28 @@
 {
-  "title": "GDCR17 for Ladies of Code & Queer Code in London",
-  "url": "http://www.queer-code.org/london/coderetreat2017/",
-  "moderators": [
-    "@d_ir",
-    "@aebar",
-    "@singsalad"
-  ],
-  "location": {
-    "city": "London",
-    "country": "United Kingdom",
-    "coordinates": {
-      "latitude": 51.517294,
-      "longitude": -0.073334
+    "location": {
+        "city": "London",
+        "coordinates": {
+            "latitude": 51.517294,
+            "longitude": -0.073334
+        },
+        "country": "United Kingdom",
+        "timezone": "Europe/London",
+        "utcOffset": 1
     },
-    "utcOffset": 1,
-    "timezone": "Europe/London"
-  }
+    "moderators": [
+        {
+            "name": "Daniel Irvine",
+            "url": "https://twitter.com/d_ir"
+        },
+        {
+            "name": "Rabea",
+            "url": "https://twitter.com/aebar"
+        },
+        {
+            "name": "Franzi [say Frun-C]",
+            "url": "https://twitter.com/singsalad"
+        }
+    ],
+    "title": "GDCR17 for Ladies of Code & Queer Code in London",
+    "url": "http://www.queer-code.org/london/coderetreat2017/"
 }

--- a/_data/events_gdcr2017/Luebeck.json
+++ b/_data/events_gdcr2017/Luebeck.json
@@ -1,17 +1,21 @@
 {
-  "title": "GDCR17 @Draeger in Luebeck",
-  "url": "http://meetu.ps/3cSr4z",
-  "moderators": [
-    "Florian Moesch",
-    "Tobias Darm"
-  ],
-  "location": {
-    "city": "Luebeck",
-    "country": "Germany",
-    "coordinates": {
-      "latitude": 53.855961,
-      "longitude": 10.6711248
+    "location": {
+        "city": "Luebeck",
+        "coordinates": {
+            "latitude": 53.855961,
+            "longitude": 10.6711248
+        },
+        "country": "Germany",
+        "timezone": "Europe/Berlin"
     },
-    "timezone": "Europe/Berlin"
-  }
+    "moderators": [
+        {
+            "name": "Florian Moesch"
+        },
+        {
+            "name": "Tobias Darm"
+        }
+    ],
+    "title": "GDCR17 @Draeger in Luebeck",
+    "url": "http://meetu.ps/3cSr4z"
 }

--- a/_data/events_gdcr2017/Lviv.json
+++ b/_data/events_gdcr2017/Lviv.json
@@ -1,18 +1,22 @@
 {
-  "title": "Coderetreat",
-  "url": "https://www.facebook.com/events/1980226588916907/",
-  "moderators": [
-    "Oleksiy Pletnov",
-    "Taras Mazurkevych"
-  ],
-  "location": {
-    "city": "Lviv",
-    "country": "Ukraine",
-    "coordinates": {
-      "latitude": 49.8327787,
-      "longitude": 23.9421959
+    "location": {
+        "city": "Lviv",
+        "coordinates": {
+            "latitude": 49.8327787,
+            "longitude": 23.9421959
+        },
+        "country": "Ukraine",
+        "timezone": "Europe/Kiev",
+        "utcOffset": 3
     },
-    "utcOffset": 3,
-    "timezone": "Europe/Kiev"
-  }
+    "moderators": [
+        {
+            "name": "Oleksiy Pletnov"
+        },
+        {
+            "name": "Taras Mazurkevych"
+        }
+    ],
+    "title": "Coderetreat",
+    "url": "https://www.facebook.com/events/1980226588916907/"
 }

--- a/_data/events_gdcr2017/Lyon.json
+++ b/_data/events_gdcr2017/Lyon.json
@@ -1,17 +1,20 @@
 {
-  "title": "GDCR17 in Lyon",
-  "url": "https://www.meetup.com/fr-FR/preview/Software-Craftsmanship-Lyon/events/244061962",
-  "moderators": [
-    "@BracherThomas"
-  ],
-  "location": {
-    "city": "Lyon",
-    "country": "France",
-    "coordinates": {
-      "latitude": 45.7578,
-      "longitude": 4.8351
+    "location": {
+        "city": "Lyon",
+        "coordinates": {
+            "latitude": 45.7578,
+            "longitude": 4.8351
+        },
+        "country": "France",
+        "timezone": "Europe/Paris",
+        "utcOffset": 1
     },
-    "utcOffset": 1,
-    "timezone": "Europe/Paris"
-  }
+    "moderators": [
+        {
+            "name": "Thomas Bracher Scolaro",
+            "url": "https://twitter.com/BracherThomas"
+        }
+    ],
+    "title": "GDCR17 in Lyon",
+    "url": "https://www.meetup.com/fr-FR/preview/Software-Craftsmanship-Lyon/events/244061962"
 }

--- a/_data/events_gdcr2017/Madrid-Southwest.json
+++ b/_data/events_gdcr2017/Madrid-Southwest.json
@@ -1,17 +1,20 @@
 {
-  "title": "GDCR17 in Madrid SouthWest",
-  "url": "https://www.meetup.com/MadridSUG/events/243703957/",
-  "moderators": [
-    "@rafael_luque"
-  ],
-  "location": {
-    "city": "Villaviciosa de Odón",
-    "country": "España",
-    "coordinates": {
-      "latitude": 40.3377904,
-      "longitude": -3.8970063
+    "location": {
+        "city": "Villaviciosa de Od\u00f3n",
+        "coordinates": {
+            "latitude": 40.3377904,
+            "longitude": -3.8970063
+        },
+        "country": "Espa\u00f1a",
+        "timezone": "Europe/Madrid",
+        "utcOffset": 2
     },
-    "utcOffset": 2,
-    "timezone": "Europe/Madrid"
-  }
+    "moderators": [
+        {
+            "name": "Rafael Luque",
+            "url": "https://twitter.com/rafael_luque"
+        }
+    ],
+    "title": "GDCR17 in Madrid SouthWest",
+    "url": "https://www.meetup.com/MadridSUG/events/243703957/"
 }

--- a/_data/events_gdcr2017/Madrid.json
+++ b/_data/events_gdcr2017/Madrid.json
@@ -1,20 +1,26 @@
 {
-  "title": "Madrid Global Day of Code Retreat 2017",
-  "url": "https://www.meetup.com/madswcraft/",
-  "moderators": [
-    "@madswcraft"
-  ],
-  "sponsors": [
-    "@idealista"
-  ],
-  "location": {
-    "city": "Madrid",
-    "country": "Spain",
-    "coordinates": {
-      "latitude": 40.4160483,
-      "longitude": -3.6983344
+    "location": {
+        "city": "Madrid",
+        "coordinates": {
+            "latitude": 40.4160483,
+            "longitude": -3.6983344
+        },
+        "country": "Spain",
+        "timezone": "Europe/Madrid",
+        "utcOffset": 2
     },
-    "utcOffset": 2,
-    "timezone": "Europe/Madrid"
-  }
+    "moderators": [
+        {
+            "name": "SW Crafters Madrid",
+            "url": "https://twitter.com/madswcraft"
+        }
+    ],
+    "sponsors": [
+        {
+            "name": "idealista",
+            "url": "https://twitter.com/idealista"
+        }
+    ],
+    "title": "Madrid Global Day of Code Retreat 2017",
+    "url": "https://www.meetup.com/madswcraft/"
 }

--- a/_data/events_gdcr2017/Malaga.json
+++ b/_data/events_gdcr2017/Malaga.json
@@ -1,21 +1,30 @@
 {
-  "title": "Málaga Global Day of Code Retreat 2017",
-  "url": "http://bit.ly/gdcr2017mlg",
-  "moderators": [
-    "@MalagaScala",
-    "@MalagaJUG"
-  ],
-  "sponsors": [
-    "@TechTalentSpain"
-  ],
-  "location": {
-    "city": "Málaga",
-    "country": "Spain",
-    "coordinates": {
-      "latitude": 36.7182015,
-      "longitude": -4.5193068
+    "location": {
+        "city": "M\u00e1laga",
+        "coordinates": {
+            "latitude": 36.7182015,
+            "longitude": -4.5193068
+        },
+        "country": "Spain",
+        "timezone": "Europe/Madrid",
+        "utcOffset": 2
     },
-    "utcOffset": 2,
-    "timezone": "Europe/Madrid"
-  }
+    "moderators": [
+        {
+            "name": "M\u00e1laga Scala Devs",
+            "url": "https://twitter.com/MalagaScala"
+        },
+        {
+            "name": "M\u00e1laga JUG",
+            "url": "https://twitter.com/MalagaJUG"
+        }
+    ],
+    "sponsors": [
+        {
+            "name": "@TechTalentSpain",
+            "url": "https://twitter.com/TechTalentSpain"
+        }
+    ],
+    "title": "M\u00e1laga Global Day of Code Retreat 2017",
+    "url": "http://bit.ly/gdcr2017mlg"
 }

--- a/_data/events_gdcr2017/Medford.json
+++ b/_data/events_gdcr2017/Medford.json
@@ -1,18 +1,24 @@
 {
-  "title": "GDCR17 Southern Oregon",
-  "url": "https://www.meetup.com/preview/southern-oregon-software-craftsmanship/events/244285720",
-  "moderators": [
-    "@randycoulman",
-    "@treveryarrish"
-  ],
-  "location": {
-    "city": "Medford",
-    "country": "United States of America",
-    "coordinates": {
-      "latitude": 42.3271456,
-      "longitude": -122.8751623
+    "location": {
+        "city": "Medford",
+        "coordinates": {
+            "latitude": 42.3271456,
+            "longitude": -122.8751623
+        },
+        "country": "United States of America",
+        "timezone": "America/Los_Angeles",
+        "utcOffset": -7
     },
-    "utcOffset": -7,
-    "timezone": "America/Los_Angeles"
-  }
+    "moderators": [
+        {
+            "name": "Randy Coulman",
+            "url": "https://twitter.com/randycoulman"
+        },
+        {
+            "name": "Trever Yarrish",
+            "url": "https://twitter.com/treveryarrish"
+        }
+    ],
+    "title": "GDCR17 Southern Oregon",
+    "url": "https://www.meetup.com/preview/southern-oregon-software-craftsmanship/events/244285720"
 }

--- a/_data/events_gdcr2017/Melbourne.json
+++ b/_data/events_gdcr2017/Melbourne.json
@@ -1,17 +1,20 @@
 {
-  "title": "GDCR17 Melbourne @Thoughtworks",
-  "url": "https://www.eventbrite.co.uk/e/global-day-of-code-retreat-tickets-39378388821",
-  "moderators": [
-    "@thelukemccarthy"
-  ],
-  "location": {
-    "city": "Melbourne",
-    "country": "Australia",
-    "coordinates": {
-      "latitude": -37.8166797,
-      "longitude": 144.9617733
+    "location": {
+        "city": "Melbourne",
+        "coordinates": {
+            "latitude": -37.8166797,
+            "longitude": 144.9617733
+        },
+        "country": "Australia",
+        "timezone": "Australia/Melbourne",
+        "utcOffset": 10
     },
-    "utcOffset": 10,
-    "timezone": "Australia/Melbourne"
-  }
+    "moderators": [
+        {
+            "name": "Luke McCarthy",
+            "url": "https://twitter.com/thelukemccarthy"
+        }
+    ],
+    "title": "GDCR17 Melbourne @Thoughtworks",
+    "url": "https://www.eventbrite.co.uk/e/global-day-of-code-retreat-tickets-39378388821"
 }

--- a/_data/events_gdcr2017/Minsk.json
+++ b/_data/events_gdcr2017/Minsk.json
@@ -1,17 +1,20 @@
 {
-  "title": "GDCR17 in Minsk",
-  "url": "https://www.meetup.com/Global-Day-of-Coderetreat-2017",
-  "moderators": [
-    "@sergyenko"
-  ],
-  "location": {
-    "city": "Minsk",
-    "country": "Belarus",
-    "coordinates": {
-      "latitude": 53.8835606,
-      "longitude": 27.438866
+    "location": {
+        "city": "Minsk",
+        "coordinates": {
+            "latitude": 53.8835606,
+            "longitude": 27.438866
+        },
+        "country": "Belarus",
+        "timezone": "Europe/Minsk",
+        "utcOffset": 3
     },
-    "utcOffset": 3,
-    "timezone": "Europe/Minsk"
-  }
+    "moderators": [
+        {
+            "name": "Sergey Sergy\u0435nko",
+            "url": "https://twitter.com/sergyenko"
+        }
+    ],
+    "title": "GDCR17 in Minsk",
+    "url": "https://www.meetup.com/Global-Day-of-Coderetreat-2017"
 }

--- a/_data/events_gdcr2017/Morgantown.json
+++ b/_data/events_gdcr2017/Morgantown.json
@@ -1,17 +1,20 @@
 {
-  "title": "GDCR17 - Morgantown",
-  "url": "https://www.meetup.com/morgantown-codes/events/242954005/",
-  "moderators": [
-    "@praisechaos"
-  ],
-  "location": {
-    "city": "Morgantown, WV",
-    "country": "United States of America",
-    "coordinates": {
-      "latitude": 39.6532451,
-      "longitude": -79.9420172
+    "location": {
+        "city": "Morgantown, WV",
+        "coordinates": {
+            "latitude": 39.6532451,
+            "longitude": -79.9420172
+        },
+        "country": "United States of America",
+        "timezone": "America/New_York",
+        "utcOffset": -4
     },
-    "utcOffset": -4,
-    "timezone": "America/New_York"
-  }
+    "moderators": [
+        {
+            "name": "Kel Cecil",
+            "url": "https://twitter.com/praisechaos"
+        }
+    ],
+    "title": "GDCR17 - Morgantown",
+    "url": "https://www.meetup.com/morgantown-codes/events/242954005/"
 }

--- a/_data/events_gdcr2017/Muenster.json
+++ b/_data/events_gdcr2017/Muenster.json
@@ -1,15 +1,20 @@
 {
-  "title": "GDCR17 @fiducia_gad in Münster",
-  "url": "https://www.softwerkskammer.org/activities/ms-gdcr-17/",
-  "location": {
-    "utcOffset": 2,
-    "timezone": "Europe/Berlin",
-    "city": "Münster",
-    "country": "Germany",
-    "coordinates": {
-      "latitude":  51.933996,
-      "longitude": 7.587291
-    }
-  },
-  "moderators": ["@ndrssmn"]
+    "location": {
+        "city": "M\u00fcnster",
+        "coordinates": {
+            "latitude": 51.933996,
+            "longitude": 7.587291
+        },
+        "country": "Germany",
+        "timezone": "Europe/Berlin",
+        "utcOffset": 2
+    },
+    "moderators": [
+        {
+            "name": "Andreas Simon",
+            "url": "https://twitter.com/ndrssmn"
+        }
+    ],
+    "title": "GDCR17 @fiducia_gad in M\u00fcnster",
+    "url": "https://www.softwerkskammer.org/activities/ms-gdcr-17/"
 }

--- a/_data/events_gdcr2017/Munich-Holidu.json
+++ b/_data/events_gdcr2017/Munich-Holidu.json
@@ -1,17 +1,20 @@
 {
-    "title": "GDCR17 in Munich at Holidu",
-    "url": "https://www.eventbrite.com/e/gdcr17-munich-at-holidu-tickets-39113169543",
-    "moderators": [
-        "@goosebumps4"
-    ],
     "location": {
         "city": "Munich",
-        "country": "Germany",
         "coordinates": {
             "latitude": 48.1788153,
             "longitude": 11.535655
         },
-        "utcOffset": 2,
-        "timezone": "Europe/Berlin"
-    }
+        "country": "Germany",
+        "timezone": "Europe/Berlin",
+        "utcOffset": 2
+    },
+    "moderators": [
+        {
+            "name": "Andrei Bechet",
+            "url": "https://twitter.com/goosebumps4"
+        }
+    ],
+    "title": "GDCR17 in Munich at Holidu",
+    "url": "https://www.eventbrite.com/e/gdcr17-munich-at-holidu-tickets-39113169543"
 }

--- a/_data/events_gdcr2017/Munich.json
+++ b/_data/events_gdcr2017/Munich.json
@@ -1,18 +1,24 @@
 {
-	"title": "GDCR17 in Munich",
-	"url": "https://www.meetup.com/de-DE/Software-Craftsmanship-Meetup-Softwerkskammer-Munchen/events/242419256/",
-	"moderators": [
-		"@davidvoelkel",
-		"@dimitrypolivaev"
-	],
-	"location": {
-		"city": "Munich",
-		"country": "Germany",
-		"coordinates": {
-			"latitude": 48.097024,
-			"longitude": 11.543011
-		},
-		"utcOffset": 2,
-		"timezone": "Europe/Berlin"
-	}
+    "location": {
+        "city": "Munich",
+        "coordinates": {
+            "latitude": 48.097024,
+            "longitude": 11.543011
+        },
+        "country": "Germany",
+        "timezone": "Europe/Berlin",
+        "utcOffset": 2
+    },
+    "moderators": [
+        {
+            "name": "David V\u00f6lkel",
+            "url": "https://twitter.com/davidvoelkel"
+        },
+        {
+            "name": "dimitrypolivaev",
+            "url": "https://twitter.com/dimitrypolivaev"
+        }
+    ],
+    "title": "GDCR17 in Munich",
+    "url": "https://www.meetup.com/de-DE/Software-Craftsmanship-Meetup-Softwerkskammer-Munchen/events/242419256/"
 }

--- a/_data/events_gdcr2017/Nagoya.json
+++ b/_data/events_gdcr2017/Nagoya.json
@@ -1,17 +1,20 @@
 {
-  "title": "CodeRetreat Nagoya GeekBar",
-  "url": "https://geekbar.doorkeeper.jp/events/66374",
-  "moderators": [
-    "@dominion525"
-  ],
-  "location": {
-    "city": "Nagoya",
-    "country": "Japan",
-    "coordinates": {
-      "latitude": 35.170239,
-      "longitude": 136.9226616
+    "location": {
+        "city": "Nagoya",
+        "coordinates": {
+            "latitude": 35.170239,
+            "longitude": 136.9226616
+        },
+        "country": "Japan",
+        "timezone": "Asia/Tokyo",
+        "utcOffset": 9
     },
-    "utcOffset": 9,
-    "timezone": "Asia/Tokyo"
-  }
+    "moderators": [
+        {
+            "name": "\u3069\u307f\u306b\u3092\u3093525",
+            "url": "https://twitter.com/dominion525"
+        }
+    ],
+    "title": "CodeRetreat Nagoya GeekBar",
+    "url": "https://geekbar.doorkeeper.jp/events/66374"
 }

--- a/_data/events_gdcr2017/Nuremberg.json
+++ b/_data/events_gdcr2017/Nuremberg.json
@@ -1,14 +1,27 @@
 {
-  "title": "GDCR17 @DATEV in Nuremberg",
-  "url": "https://ti.to/gdcr-nuernberg/2017",
-  "location": {
-    "timezone": "Europe/Berlin",
-    "city": "Nuremberg",
-    "country": "Germany",
-    "coordinates": {
-      "latitude": 49.4538600,
-      "longitude": 11.0432813
-    }
-  },
-  "moderators": ["@Fischermaen", "@xelamrelos", "@marcoemrich"]
+    "location": {
+        "city": "Nuremberg",
+        "coordinates": {
+            "latitude": 49.45386,
+            "longitude": 11.0432813
+        },
+        "country": "Germany",
+        "timezone": "Europe/Berlin"
+    },
+    "moderators": [
+        {
+            "name": "Andy Fischer",
+            "url": "https://twitter.com/Fischermaen"
+        },
+        {
+            "name": "Alex Soler Sanandres",
+            "url": "https://twitter.com/xelamrelos"
+        },
+        {
+            "name": "Marco Emrich",
+            "url": "https://twitter.com/marcoemrich"
+        }
+    ],
+    "title": "GDCR17 @DATEV in Nuremberg",
+    "url": "https://ti.to/gdcr-nuernberg/2017"
 }

--- a/_data/events_gdcr2017/Oaxaca.json
+++ b/_data/events_gdcr2017/Oaxaca.json
@@ -1,26 +1,50 @@
 {
-  "title": "Global Day of Code Retreat 2017 Oaxaca, México",
-  "url": "https://www.eventbrite.com/e/global-day-of-coderetreat-oaxaca-2017-tickets-39236483378",
-  "moderators": [
-    "@oaxacarb",
-    "@fervisa",
-    "@garcialopezco",
-    "@sudo_silva"
-  ],
-  "sponsors": [
-    "@logicalbricks",
-    "@CoworkInnMX",
-    "@UxiErp",
-    "@via4grafico"
-  ],
-  "location": {
-    "city": "Oaxaca",
-    "country": "México",
-    "coordinates": {
-      "latitude": 17.0714374,
-      "longitude": -96.714961
+    "location": {
+        "city": "Oaxaca",
+        "coordinates": {
+            "latitude": 17.0714374,
+            "longitude": -96.714961
+        },
+        "country": "M\u00e9xico",
+        "timezone": "America/Mexico_City",
+        "utcOffset": -5
     },
-    "utcOffset": -5,
-    "timezone": "America/Mexico_City"
-  }
+    "moderators": [
+        {
+            "name": "oaxaca.rb",
+            "url": "https://twitter.com/oaxacarb"
+        },
+        {
+            "name": "Fernando Villalobos",
+            "url": "https://twitter.com/fervisa"
+        },
+        {
+            "name": "Chars",
+            "url": "https://twitter.com/garcialopezco"
+        },
+        {
+            "name": "Luis Silva",
+            "url": "https://twitter.com/sudo_silva"
+        }
+    ],
+    "sponsors": [
+        {
+            "name": "LogicalBricks",
+            "url": "https://twitter.com/logicalbricks"
+        },
+        {
+            "name": "Cowork Inn",
+            "url": "https://twitter.com/CoworkInnMX"
+        },
+        {
+            "name": "Soporte Uxi erp",
+            "url": "https://twitter.com/UxiErp"
+        },
+        {
+            "name": "via4",
+            "url": "https://twitter.com/via4grafico"
+        }
+    ],
+    "title": "Global Day of Code Retreat 2017 Oaxaca, M\u00e9xico",
+    "url": "https://www.eventbrite.com/e/global-day-of-coderetreat-oaxaca-2017-tickets-39236483378"
 }

--- a/_data/events_gdcr2017/Olomouc.json
+++ b/_data/events_gdcr2017/Olomouc.json
@@ -1,15 +1,24 @@
 {
-  "title": "GDCR 2017 in Olomouc",
-  "url": "https://www.meetup.com/CodeRetreat-CZ/events/243354375/",
-  "moderators": ["@tomaslatal", "@mcBIGcz"],
-  "location": {
-    "city": "Olomouc",
-    "country": "Czech Republic",
-    "coordinates": {
-      "latitude": 49.5927391,
-      "longitude": 17.2710174
+    "location": {
+        "city": "Olomouc",
+        "coordinates": {
+            "latitude": 49.5927391,
+            "longitude": 17.2710174
+        },
+        "country": "Czech Republic",
+        "timezone": "Europe/Vienna",
+        "utcOffset": 2
     },
-    "utcOffset": 2,
-    "timezone": "Europe/Vienna"
-  }
+    "moderators": [
+        {
+            "name": "Tomas Latal",
+            "url": "https://twitter.com/tomaslatal"
+        },
+        {
+            "name": "Dalibor Flori\u00e1n",
+            "url": "https://twitter.com/mcBIGcz"
+        }
+    ],
+    "title": "GDCR 2017 in Olomouc",
+    "url": "https://www.meetup.com/CodeRetreat-CZ/events/243354375/"
 }

--- a/_data/events_gdcr2017/Osaka.json
+++ b/_data/events_gdcr2017/Osaka.json
@@ -1,17 +1,20 @@
 {
-  "title": "Global Day of Coderetreat 2017 in Osaka",
-  "url": "https://connpass.com/event/68170/",
-  "moderators": [
-    "@kawakawa"
-  ],
-  "location": {
-    "city": "Osaka",
-    "country": "Japan",
-    "coordinates": {
-      "latitude": 34.6874499,
-      "longitude": 135.4962912
+    "location": {
+        "city": "Osaka",
+        "coordinates": {
+            "latitude": 34.6874499,
+            "longitude": 135.4962912
+        },
+        "country": "Japan",
+        "timezone": "Asia/Tokyo",
+        "utcOffset": 9
     },
-    "utcOffset": 9,
-    "timezone": "Asia/Tokyo"
-  }
+    "moderators": [
+        {
+            "name": "\u304b\u308f\u3079\u3000\u305f\u304f\u3084",
+            "url": "https://twitter.com/kawakawa"
+        }
+    ],
+    "title": "Global Day of Coderetreat 2017 in Osaka",
+    "url": "https://connpass.com/event/68170/"
 }

--- a/_data/events_gdcr2017/Palma.json
+++ b/_data/events_gdcr2017/Palma.json
@@ -1,20 +1,32 @@
 {
-  "title": "Global Day of Coderetreat @ Mallorca",
-  "url": "https://www.meetup.com/es-ES/Mallorca-Software-Craftsmanship/events/244065071/",
-  "moderators": [
-    "@scmallorca",
-    "@jllado",
-    "@danipise",
-    "@jrodriguezgalan"
-  ],
-  "location": {
-    "city": "Palma de Mallorca",
-    "country": "Spain",
-    "coordinates": {
-      "latitude": 39.6366589,
-      "longitude": 2.6285283
+    "location": {
+        "city": "Palma de Mallorca",
+        "coordinates": {
+            "latitude": 39.6366589,
+            "longitude": 2.6285283
+        },
+        "country": "Spain",
+        "timezone": "Europe/Madrid",
+        "utcOffset": 2
     },
-    "utcOffset": 2,
-    "timezone": "Europe/Madrid"
-  }
+    "moderators": [
+        {
+            "name": "Mallorca SW Craft",
+            "url": "https://twitter.com/scmallorca"
+        },
+        {
+            "name": "Juan Llad\u00f3",
+            "url": "https://twitter.com/jllado"
+        },
+        {
+            "name": "Daniel Pi\u00f1eiro",
+            "url": "https://twitter.com/danipise"
+        },
+        {
+            "name": "Jorge R. G.",
+            "url": "https://twitter.com/jrodriguezgalan"
+        }
+    ],
+    "title": "Global Day of Coderetreat @ Mallorca",
+    "url": "https://www.meetup.com/es-ES/Mallorca-Software-Craftsmanship/events/244065071/"
 }

--- a/_data/events_gdcr2017/Pamplona.json
+++ b/_data/events_gdcr2017/Pamplona.json
@@ -1,20 +1,26 @@
 {
-  "title": "Global Day of Coderetreat 2017 in Pamplona, facilitated by Openbravo",
-  "url": "https://www.eventbrite.es/e/entradas-openbravo-coderetreat-2017-pair-programming-tdd-y-buenas-practicas-de-desarrollo-38432353203",
-  "moderators": [
-    "@AugustoMauch"
-  ],
-  "sponsors": [
-    "@Openbravo"
-  ],
-  "location": {
-    "city": "Mutilva",
-    "country": "Spain",
-    "coordinates": {
-      "latitude": 42.79674389424998,
-      "longitude": -1.6133970022189033
+    "location": {
+        "city": "Mutilva",
+        "coordinates": {
+            "latitude": 42.79674389424998,
+            "longitude": -1.6133970022189033
+        },
+        "country": "Spain",
+        "timezone": "Europe/Madrid",
+        "utcOffset": 2
     },
-    "utcOffset": 2,
-    "timezone": "Europe/Madrid"
-  }
+    "moderators": [
+        {
+            "name": "Augusto Mauch",
+            "url": "https://twitter.com/AugustoMauch"
+        }
+    ],
+    "sponsors": [
+        {
+            "name": "Openbravo",
+            "url": "https://twitter.com/Openbravo"
+        }
+    ],
+    "title": "Global Day of Coderetreat 2017 in Pamplona, facilitated by Openbravo",
+    "url": "https://www.eventbrite.es/e/entradas-openbravo-coderetreat-2017-pair-programming-tdd-y-buenas-practicas-de-desarrollo-38432353203"
 }

--- a/_data/events_gdcr2017/Paris.json
+++ b/_data/events_gdcr2017/Paris.json
@@ -1,18 +1,24 @@
 {
-  "title": "Global Day of Code Retreat @ OCTO",
-  "url": "https://www.eventbrite.fr/e/billets-global-day-of-code-retreat-octo-38777450398",
-  "moderators": [
-    "@nicoespeon",
-    "@adibolb"
-  ],
-  "location": {
-    "city": "Paris",
-    "country": "France",
-    "coordinates": {
-      "latitude": 48.8686208,
-      "longitude": 2.3314411
+    "location": {
+        "city": "Paris",
+        "coordinates": {
+            "latitude": 48.8686208,
+            "longitude": 2.3314411
+        },
+        "country": "France",
+        "timezone": "Europe/Paris",
+        "utcOffset": 2
     },
-    "utcOffset": 2,
-    "timezone": "Europe/Paris"
-  }
+    "moderators": [
+        {
+            "name": "Nicolas Carlo",
+            "url": "https://twitter.com/nicoespeon"
+        },
+        {
+            "name": "Adrian Bolboaca",
+            "url": "https://twitter.com/adibolb"
+        }
+    ],
+    "title": "Global Day of Code Retreat @ OCTO",
+    "url": "https://www.eventbrite.fr/e/billets-global-day-of-code-retreat-octo-38777450398"
 }

--- a/_data/events_gdcr2017/Paris_.json
+++ b/_data/events_gdcr2017/Paris_.json
@@ -1,20 +1,26 @@
 {
-  "title": "GDCR17 in Paris by Nexeo",
-  "url": "https://global-day-of-code-retreat-by-nexeo.eventbrite.com",
-  "moderators": [
-    "@Nils_Back"
-  ],
-  "sponsors": [
-    "@NexeoFinance"
-  ],
-  "location": {
-    "city": "Paris",
-    "country": "France",
-    "coordinates": {
-      "latitude": 48.8589507,
-      "longitude": 2.2770205
+    "location": {
+        "city": "Paris",
+        "coordinates": {
+            "latitude": 48.8589507,
+            "longitude": 2.2770205
+        },
+        "country": "France",
+        "timezone": "Europe/Paris",
+        "utcOffset": 2
     },
-    "utcOffset": 2,
-    "timezone": "Europe/Paris"
-  }
+    "moderators": [
+        {
+            "name": "Nils Lesieur",
+            "url": "https://twitter.com/Nils_Back"
+        }
+    ],
+    "sponsors": [
+        {
+            "name": "Nexeo Groupe",
+            "url": "https://twitter.com/NexeoFinance"
+        }
+    ],
+    "title": "GDCR17 in Paris by Nexeo",
+    "url": "https://global-day-of-code-retreat-by-nexeo.eventbrite.com"
 }

--- a/_data/events_gdcr2017/Pisek.json
+++ b/_data/events_gdcr2017/Pisek.json
@@ -1,19 +1,28 @@
 {
-  "title": "GDCR17 in TCPísek",
-  "url": "https://www.meetup.com/CodeRetreat-CZ/events/243880403",
-  "moderators": [
-    "@hlavacm",
-    "@honzalilak",
-    "@twista"
-  ],
-  "location": {
-    "city": "Písek",
-    "country": "Czech Republic",
-    "coordinates": {
-      "latitude": 49.313686,
-      "longitude": 14.1353833
+    "location": {
+        "city": "P\u00edsek",
+        "coordinates": {
+            "latitude": 49.313686,
+            "longitude": 14.1353833
+        },
+        "country": "Czech Republic",
+        "timezone": "Europe/Prague",
+        "utcOffset": 2
     },
-    "utcOffset": 2,
-    "timezone": "Europe/Prague"
-  }
+    "moderators": [
+        {
+            "name": "Martin Hlav",
+            "url": "https://twitter.com/hlavacm"
+        },
+        {
+            "name": "Honza Lil\u00e1k",
+            "url": "https://twitter.com/honzalilak"
+        },
+        {
+            "name": "\u015feyma",
+            "url": "https://twitter.com/twista"
+        }
+    ],
+    "title": "GDCR17 in TCP\u00edsek",
+    "url": "https://www.meetup.com/CodeRetreat-CZ/events/243880403"
 }

--- a/_data/events_gdcr2017/Pittsburgh.json
+++ b/_data/events_gdcr2017/Pittsburgh.json
@@ -1,17 +1,20 @@
 {
-  "title": "GDCR17 Pittsburgh",
-  "url": "https://www.meetup.com/Pittsburgh-Code-Supply/events/242232762/",
-  "moderators": [
-    "@jthurne"
-  ],
-  "location": {
-    "city": "Pittsburgh",
-    "country": "United States of America",
-    "coordinates": {
-      "latitude": 40.4598516,
-      "longitude": -79.9306494
+    "location": {
+        "city": "Pittsburgh",
+        "coordinates": {
+            "latitude": 40.4598516,
+            "longitude": -79.9306494
+        },
+        "country": "United States of America",
+        "timezone": "America/New_York",
+        "utcOffset": -4
     },
-    "utcOffset": -4,
-    "timezone": "America/New_York"
-  }
+    "moderators": [
+        {
+            "name": "Jim Hurne",
+            "url": "https://twitter.com/jthurne"
+        }
+    ],
+    "title": "GDCR17 Pittsburgh",
+    "url": "https://www.meetup.com/Pittsburgh-Code-Supply/events/242232762/"
 }

--- a/_data/events_gdcr2017/Pordenone.json
+++ b/_data/events_gdcr2017/Pordenone.json
@@ -1,18 +1,24 @@
 {
-  "title": "Global Day of Coderetreat 2017 - Pordenone",
-  "url": "https://www.eventbrite.com/e/global-day-of-coderetreat-2017-pordenone-tickets-37976643162",
-  "moderators": [
-    "@dlondero",
-    "@pozzobondaniele"
-  ],
-  "location": {
-    "city": "Pordenone",
-    "country": "Italy",
-    "coordinates": {
-      "latitude": 45.9589747,
-      "longitude": 12.6630343
+    "location": {
+        "city": "Pordenone",
+        "coordinates": {
+            "latitude": 45.9589747,
+            "longitude": 12.6630343
+        },
+        "country": "Italy",
+        "timezone": "Europe/Rome",
+        "utcOffset": 2
     },
-    "utcOffset": 2,
-    "timezone": "Europe/Rome"
-  }
+    "moderators": [
+        {
+            "name": "dlondero [Need PHP help?]",
+            "url": "https://twitter.com/dlondero"
+        },
+        {
+            "name": "Daniele Pozzobon",
+            "url": "https://twitter.com/pozzobondaniele"
+        }
+    ],
+    "title": "Global Day of Coderetreat 2017 - Pordenone",
+    "url": "https://www.eventbrite.com/e/global-day-of-coderetreat-2017-pordenone-tickets-37976643162"
 }

--- a/_data/events_gdcr2017/Portland.json
+++ b/_data/events_gdcr2017/Portland.json
@@ -1,15 +1,20 @@
 {
-  "title": "PDX Global Day of Coderetreat 2017",
-  "url": "https://www.meetup.com/PDX-Software-Practice/events/242965451/",
-  "location": {
-    "utcOffset": -8,
-    "timezone": "America/Los_Angeles",
-    "city": "Portland, OR",
-    "country": "United States of America",
-    "coordinates": {
-      "latitude": 45.5425909,
-      "longitude": -122.7948507
-    }
-  },
-  "moderators": ["@mplavcan"]
+    "location": {
+        "city": "Portland, OR",
+        "coordinates": {
+            "latitude": 45.5425909,
+            "longitude": -122.7948507
+        },
+        "country": "United States of America",
+        "timezone": "America/Los_Angeles",
+        "utcOffset": -8
+    },
+    "moderators": [
+        {
+            "name": "Matt Plavcan",
+            "url": "https://twitter.com/mplavcan"
+        }
+    ],
+    "title": "PDX Global Day of Coderetreat 2017",
+    "url": "https://www.meetup.com/PDX-Software-Practice/events/242965451/"
 }

--- a/_data/events_gdcr2017/Portland2017.json
+++ b/_data/events_gdcr2017/Portland2017.json
@@ -1,11 +1,21 @@
 {
-  "title": "Global Day of Coderetreat",
-  "url": "https://www.eventbrite.com/e/pdx-women-in-tech-pdxwit-global-day-of-code-retreat-tickets-38483100991?aff=eac2",
-  "moderators": ["Iman Bilal", "Tracie Lee", "Jean Richardson"],
-  "location": {
-    "utcOffset": -8,
-    "timezone": "America/Los_Angeles",
-    "city": "Portland, OR",
-    "country": "United States of America"
-  }
+    "location": {
+        "city": "Portland, OR",
+        "country": "United States of America",
+        "timezone": "America/Los_Angeles",
+        "utcOffset": -8
+    },
+    "moderators": [
+        {
+            "name": "Iman Bilal"
+        },
+        {
+            "name": "Tracie Lee"
+        },
+        {
+            "name": "Jean Richardson"
+        }
+    ],
+    "title": "Global Day of Coderetreat",
+    "url": "https://www.eventbrite.com/e/pdx-women-in-tech-pdxwit-global-day-of-code-retreat-tickets-38483100991?aff=eac2"
 }

--- a/_data/events_gdcr2017/Poznan.json
+++ b/_data/events_gdcr2017/Poznan.json
@@ -1,17 +1,19 @@
 {
-  "title": "GDCR 17 in Poznañ",
-  "url": "https://gdcrpoznan17.eventbrite.com/",
-  "moderators": [
-    "Wojciech Buras"
-  ],
-  "location": {
-    "city": "Poznañ",
-    "country": "Poland",
-    "coordinates": {
-      "latitude": 52.4036003,
-      "longitude": 16.9136073
+    "location": {
+        "city": "Pozna\u00f1",
+        "coordinates": {
+            "latitude": 52.4036003,
+            "longitude": 16.9136073
+        },
+        "country": "Poland",
+        "timezone": "Europe/Warsaw",
+        "utcOffset": 2
     },
-    "utcOffset": 2,
-    "timezone": "Europe/Warsaw"
-  }
+    "moderators": [
+        {
+            "name": "Wojciech Buras"
+        }
+    ],
+    "title": "GDCR 17 in Pozna\u00f1",
+    "url": "https://gdcrpoznan17.eventbrite.com/"
 }

--- a/_data/events_gdcr2017/Prague.json
+++ b/_data/events_gdcr2017/Prague.json
@@ -1,20 +1,32 @@
 {
-  "title": "GDCR17 in Prague",
-  "url": "https://www.meetup.com/CodeRetreat-CZ/events/243105898/",
-  "moderators": [
-    "@coderetreatcz",
-    "@alesroubicek",
-    "@jirkapenzes",
-    "@marianschubert"
-  ],
-  "location": {
-    "city": "Prague",
-    "country": "Czech Republic",
-    "coordinates": {
-      "latitude": 50.0595854,
-      "longitude": 14.3255418
+    "location": {
+        "city": "Prague",
+        "coordinates": {
+            "latitude": 50.0595854,
+            "longitude": 14.3255418
+        },
+        "country": "Czech Republic",
+        "timezone": "Europe/Prague",
+        "utcOffset": 2
     },
-    "utcOffset": 2,
-    "timezone": "Europe/Prague"
-  }
+    "moderators": [
+        {
+            "name": "Coderetreat CZ",
+            "url": "https://twitter.com/coderetreatcz"
+        },
+        {
+            "name": "Ale\u0161 Roub\u00ed\u010dek",
+            "url": "https://twitter.com/alesroubicek"
+        },
+        {
+            "name": "Jirka P\u00e9nze\u0161",
+            "url": "https://twitter.com/jirkapenzes"
+        },
+        {
+            "name": "Marian Schubert",
+            "url": "https://twitter.com/marianschubert"
+        }
+    ],
+    "title": "GDCR17 in Prague",
+    "url": "https://www.meetup.com/CodeRetreat-CZ/events/243105898/"
 }

--- a/_data/events_gdcr2017/Pune-2.json
+++ b/_data/events_gdcr2017/Pune-2.json
@@ -1,22 +1,34 @@
 {
-    "title": "GDCR17 e-Zest, Pune",
-    "url": "http://www.e-zest.com/gdcr-2017",
-    "moderators": [
-        "@christianhujer",
-        "@ShwetaSadawarte"
-    ],
-    "sponsors": [
-        "@nelkinda",
-        "@ezest"
-    ],
     "location": {
         "city": "Pune",
-        "country": "India",
         "coordinates": {
             "latitude": 18.578799,
             "longitude": 73.7378663
         },
-        "utcOffset": 5.5,
-        "timezone": "Asia/Kolkata"
-    }
+        "country": "India",
+        "timezone": "Asia/Kolkata",
+        "utcOffset": 5.5
+    },
+    "moderators": [
+        {
+            "name": "Christian Hujer",
+            "url": "https://twitter.com/christianhujer"
+        },
+        {
+            "name": "Shweta Sadawarte",
+            "url": "https://twitter.com/ShwetaSadawarte"
+        }
+    ],
+    "sponsors": [
+        {
+            "name": "Nelkinda",
+            "url": "https://twitter.com/nelkinda"
+        },
+        {
+            "name": "e-Zest Solutions",
+            "url": "https://twitter.com/ezest"
+        }
+    ],
+    "title": "GDCR17 e-Zest, Pune",
+    "url": "http://www.e-zest.com/gdcr-2017"
 }

--- a/_data/events_gdcr2017/Pune-3.json
+++ b/_data/events_gdcr2017/Pune-3.json
@@ -1,23 +1,38 @@
 {
-    "title": "GDCR17 SimplyTech / Perennial Systems, Pune",
-    "url": "https://www.meetup.com/SimplyTech/events/244860687",
-    "moderators": [
-        "@bharatikoot",
-        "@rkreddykonyala"
-    ],
-    "sponsors": [
-        "@nelkinda",
-        "@perennialsys",
-        "@simplytech_in"
-    ],
     "location": {
         "city": "Pune",
-        "country": "India",
         "coordinates": {
             "latitude": 18.483507,
             "longitude": 73.8555663
         },
-        "utcOffset": 5.5,
-        "timezone": "Asia/Kolkata"
-    }
+        "country": "India",
+        "timezone": "Asia/Kolkata",
+        "utcOffset": 5.5
+    },
+    "moderators": [
+        {
+            "name": "Bharati Bastade Koot",
+            "url": "https://twitter.com/bharatikoot"
+        },
+        {
+            "name": "Rama Krishna",
+            "url": "https://twitter.com/rkreddykonyala"
+        }
+    ],
+    "sponsors": [
+        {
+            "name": "Nelkinda",
+            "url": "https://twitter.com/nelkinda"
+        },
+        {
+            "name": "@perennialsys",
+            "url": "https://twitter.com/perennialsys"
+        },
+        {
+            "name": "SimplyTech",
+            "url": "https://twitter.com/simplytech_in"
+        }
+    ],
+    "title": "GDCR17 SimplyTech / Perennial Systems, Pune",
+    "url": "https://www.meetup.com/SimplyTech/events/244860687"
 }

--- a/_data/events_gdcr2017/Pune-4.json
+++ b/_data/events_gdcr2017/Pune-4.json
@@ -1,22 +1,34 @@
 {
-    "title": "GDCR17 Codewords / Red Panda, Pune",
-    "url": "https://www.meetup.com/Codewords-Pune/events/244860413",
-    "moderators": [
-        "@_sameersoni"
-    ],
-    "sponsors": [
-        "@nelkinda",
-        "@Codewords01",
-        "@theredpandalabs"
-    ],
     "location": {
         "city": "Pune",
-        "country": "India",
         "coordinates": {
             "latitude": 18.545057,
             "longitude": 73.9076073
         },
-        "utcOffset": 5.5,
-        "timezone": "Asia/Kolkata"
-    }
+        "country": "India",
+        "timezone": "Asia/Kolkata",
+        "utcOffset": 5.5
+    },
+    "moderators": [
+        {
+            "name": "Sameer Soni",
+            "url": "https://twitter.com/_sameersoni"
+        }
+    ],
+    "sponsors": [
+        {
+            "name": "Nelkinda",
+            "url": "https://twitter.com/nelkinda"
+        },
+        {
+            "name": "Codewords",
+            "url": "https://twitter.com/Codewords01"
+        },
+        {
+            "name": "RedPanda Labs",
+            "url": "https://twitter.com/theredpandalabs"
+        }
+    ],
+    "title": "GDCR17 Codewords / Red Panda, Pune",
+    "url": "https://www.meetup.com/Codewords-Pune/events/244860413"
 }

--- a/_data/events_gdcr2017/Pune.json
+++ b/_data/events_gdcr2017/Pune.json
@@ -1,20 +1,26 @@
 {
-    "title": "GDCR17 Nelkinda, Pune",
-    "url": "http://nelkinda.com/events/2017/11/18/Global-Day-of-Coderetreat/pune-nelkinda",
-    "moderators": [
-        "@SiddheshNikude"
-    ],
-    "sponsors": [
-        "@nelkinda"
-    ],
     "location": {
         "city": "Pune",
-        "country": "India",
         "coordinates": {
             "latitude": 18.521246,
             "longitude": 73.7764523
         },
-        "utcOffset": 5.5,
-        "timezone": "Asia/Kolkata"
-    }
+        "country": "India",
+        "timezone": "Asia/Kolkata",
+        "utcOffset": 5.5
+    },
+    "moderators": [
+        {
+            "name": "Siddhesh Nikude",
+            "url": "https://twitter.com/SiddheshNikude"
+        }
+    ],
+    "sponsors": [
+        {
+            "name": "Nelkinda",
+            "url": "https://twitter.com/nelkinda"
+        }
+    ],
+    "title": "GDCR17 Nelkinda, Pune",
+    "url": "http://nelkinda.com/events/2017/11/18/Global-Day-of-Coderetreat/pune-nelkinda"
 }

--- a/_data/events_gdcr2017/Quito.json
+++ b/_data/events_gdcr2017/Quito.json
@@ -1,17 +1,20 @@
 {
-  "title": "Global Day of Coderetreat 2017 in Quito-Ecuador",
-  "url": "https://www.meetup.com/es-ES/ThoughtWorks-Ecuador/events/243340544/",
-  "moderators": [
-    "@emmeblm"
-  ],
-  "location": {
-    "city": "Quito",
-    "country": "Ecuador",
-    "coordinates": {
-      "latitude": -0.1858189,
-      "longitude": -78.4825211
+    "location": {
+        "city": "Quito",
+        "coordinates": {
+            "latitude": -0.1858189,
+            "longitude": -78.4825211
+        },
+        "country": "Ecuador",
+        "timezone": "America/Guayaquil",
+        "utcOffset": -5
     },
-    "utcOffset": -5,
-    "timezone": "America/Guayaquil"
-  }
+    "moderators": [
+        {
+            "name": "Luisa",
+            "url": "https://twitter.com/emmeblm"
+        }
+    ],
+    "title": "Global Day of Coderetreat 2017 in Quito-Ecuador",
+    "url": "https://www.meetup.com/es-ES/ThoughtWorks-Ecuador/events/243340544/"
 }

--- a/_data/events_gdcr2017/Rennes.json
+++ b/_data/events_gdcr2017/Rennes.json
@@ -1,19 +1,28 @@
 {
-    "title": "GDCR 2017 in Rennes",
-    "url": "https://www.meetup.com/fr-FR/Software-Craftsmanship-Rennes/events/244037122/",
-    "moderators": [
-    "@gcollic",
-    "@y0anr",
-    "@gsalaun1"
-],
     "location": {
-    "city": "Rennes",
-        "country": "France",
+        "city": "Rennes",
         "coordinates": {
-        "latitude": 48.1120266,
+            "latitude": 48.1120266,
             "longitude": -1.6884867
+        },
+        "country": "France",
+        "timezone": "Europe/Paris",
+        "utcOffset": 2
     },
-    "utcOffset": 2,
-        "timezone": "Europe/Paris"
-}
+    "moderators": [
+        {
+            "name": "Guillaume Collic \u21bb",
+            "url": "https://twitter.com/gcollic"
+        },
+        {
+            "name": "@y0anr",
+            "url": "https://twitter.com/y0anr"
+        },
+        {
+            "name": "Ga\u00ebl Sala\u00fcn",
+            "url": "https://twitter.com/gsalaun1"
+        }
+    ],
+    "title": "GDCR 2017 in Rennes",
+    "url": "https://www.meetup.com/fr-FR/Software-Craftsmanship-Rennes/events/244037122/"
 }

--- a/_data/events_gdcr2017/Riga.json
+++ b/_data/events_gdcr2017/Riga.json
@@ -1,18 +1,24 @@
 {
-  "title": "GDCR17 in Riga",
-  "url": "https://www.meetup.com/Latvian-Developers-Network/events/238511203/",
-  "moderators": [
-    "@acankr",
-    "@arkadi_t"
-  ],
-  "location": {
-    "city": "Riga",
-    "country": "Latvia",
-    "coordinates": {
-    	"latitude": 56.97019,
-    	"longitude": 24.157375
+    "location": {
+        "city": "Riga",
+        "coordinates": {
+            "latitude": 56.97019,
+            "longitude": 24.157375
+        },
+        "country": "Latvia",
+        "timezone": "Europe/Riga",
+        "utcOffset": 3
     },
-    "utcOffset": 3,
-    "timezone": "Europe/Riga"
-  }
+    "moderators": [
+        {
+            "name": "Antons Kranga",
+            "url": "https://twitter.com/acankr"
+        },
+        {
+            "name": "Arkadi Shishlov",
+            "url": "https://twitter.com/arkadi_t"
+        }
+    ],
+    "title": "GDCR17 in Riga",
+    "url": "https://www.meetup.com/Latvian-Developers-Network/events/238511203/"
 }

--- a/_data/events_gdcr2017/SLC.json
+++ b/_data/events_gdcr2017/SLC.json
@@ -1,15 +1,24 @@
 {
-  "title": "GDCR17 in SLC",
-  "url": "https://www.meetup.com/UtahJS/events/243091877/",
-  "moderators": ["@version2beta", "@_metasean"],
-  "location": {
-    "city": "Salt Lake City, Utah",
-    "country": "United States of America",
-    "coordinates": {
-      "latitude": 40.765887,
-      "longitude": -111.8909577
+    "location": {
+        "city": "Salt Lake City, Utah",
+        "coordinates": {
+            "latitude": 40.765887,
+            "longitude": -111.8909577
+        },
+        "country": "United States of America",
+        "timezone": "MST7MDT",
+        "utcOffset": -6
     },
-    "utcOffset": -6,
-    "timezone": "MST7MDT"
-  }
+    "moderators": [
+        {
+            "name": "rob martin",
+            "url": "https://twitter.com/version2beta"
+        },
+        {
+            "name": "@_metasean",
+            "url": "https://twitter.com/_metasean"
+        }
+    ],
+    "title": "GDCR17 in SLC",
+    "url": "https://www.meetup.com/UtahJS/events/243091877/"
 }

--- a/_data/events_gdcr2017/Saint-Petersburg.json
+++ b/_data/events_gdcr2017/Saint-Petersburg.json
@@ -1,15 +1,15 @@
 {
-  "title": "GDCR in Saint-Petersburg",
-  "url": "https://events.epam.com/events/global-day-of-coderetreat",
-  "moderators": [],
-  "location": {
-    "city": "Saint-Petersburg",
-    "country": "Russia",
-    "coordinates": {
-      "latitude": 59.9174925,
-      "longitude": 30.0448869
+    "location": {
+        "city": "Saint-Petersburg",
+        "coordinates": {
+            "latitude": 59.9174925,
+            "longitude": 30.0448869
+        },
+        "country": "Russia",
+        "timezone": "Europe/Moscow",
+        "utcOffset": 4
     },
-    "utcOffset": 4,
-    "timezone": "Europe/Moscow"
-  }
+    "moderators": [],
+    "title": "GDCR in Saint-Petersburg",
+    "url": "https://events.epam.com/events/global-day-of-coderetreat"
 }

--- a/_data/events_gdcr2017/Santiago.json
+++ b/_data/events_gdcr2017/Santiago.json
@@ -1,23 +1,44 @@
 {
-  "title": "GDCR17 in Santiago, Chile",
-  "url": "https://www.meetup.com/preview/Software-Crafters-Chile/events/244512436",
-  "moderators": [
-    "@chile_socrates",
-    "@almanegreteshen",
-    "@taichi2000",
-    "@davidlaym",
-    "@JosephCastroR",
-    "@jchacana",
-    "@morph3o"
-  ],
-  "location": {
-    "city": "Santiago",
-    "country": "Chile",
-    "coordinates": {
-      "latitude": -33.4724727,
-      "longitude": -70.9100286
+    "location": {
+        "city": "Santiago",
+        "coordinates": {
+            "latitude": -33.4724727,
+            "longitude": -70.9100286
+        },
+        "country": "Chile",
+        "timezone": "America/Santiago",
+        "utcOffset": -4
     },
-    "utcOffset": -4,
-    "timezone": "America/Santiago"
-  }
+    "moderators": [
+        {
+            "name": "SoCraTes Chile",
+            "url": "https://twitter.com/chile_socrates"
+        },
+        {
+            "name": "Alma Negrete Shen",
+            "url": "https://twitter.com/almanegreteshen"
+        },
+        {
+            "name": "Germ\u00e1n Gonz\u00e1lez",
+            "url": "https://twitter.com/taichi2000"
+        },
+        {
+            "name": "David Lay",
+            "url": "https://twitter.com/davidlaym"
+        },
+        {
+            "name": "Jos\u00e9 Castro",
+            "url": "https://twitter.com/JosephCastroR"
+        },
+        {
+            "name": "Javier Chacana",
+            "url": "https://twitter.com/jchacana"
+        },
+        {
+            "name": "Piero Divasto",
+            "url": "https://twitter.com/morph3o"
+        }
+    ],
+    "title": "GDCR17 in Santiago, Chile",
+    "url": "https://www.meetup.com/preview/Software-Crafters-Chile/events/244512436"
 }

--- a/_data/events_gdcr2017/Saskatoon.json
+++ b/_data/events_gdcr2017/Saskatoon.json
@@ -1,18 +1,19 @@
 {
-  "title": "GDCR17 @SED in Saskatoon",
-  "url": "https://ti.to/global-day-of-code-retreat-sed-systems/gdcr-2017",
-  "moderators": [
-    "Devin Greene"
-  ],
-  "location": {
-    "city": "Saskatoon",
-    "country": "Canada",
-    "coordinates": {
-      "latitude": 52.1420383,
-      "longitude": -106.6215119
+    "location": {
+        "city": "Saskatoon",
+        "coordinates": {
+            "latitude": 52.1420383,
+            "longitude": -106.6215119
+        },
+        "country": "Canada",
+        "timezone": "America/Regina",
+        "utcOffset": -6
     },
-    "utcOffset": -6,
-    "timezone": "America/Regina"
-  }
+    "moderators": [
+        {
+            "name": "Devin Greene"
+        }
+    ],
+    "title": "GDCR17 @SED in Saskatoon",
+    "url": "https://ti.to/global-day-of-code-retreat-sed-systems/gdcr-2017"
 }
-

--- a/_data/events_gdcr2017/Seattle-Expedia.json
+++ b/_data/events_gdcr2017/Seattle-Expedia.json
@@ -1,14 +1,14 @@
 {
-  "title": "Global Day of Coderetreat 2017 - Expedia Seattle",
-  "url": "https://www.eventbrite.com/e/global-day-of-coderetreat-expedia-seattle-tickets-38775140489",
-  "location": {
-    "utcOffset": -8,
-    "timezone": "America/Los_Angeles",
-    "city": "Seattle, WA",
-    "country": "United States of America",
-    "coordinates": {
-      "latitude": 47.625900,
-      "longitude": -122.368500
-    }
-  }
+    "location": {
+        "city": "Seattle, WA",
+        "coordinates": {
+            "latitude": 47.6259,
+            "longitude": -122.3685
+        },
+        "country": "United States of America",
+        "timezone": "America/Los_Angeles",
+        "utcOffset": -8
+    },
+    "title": "Global Day of Coderetreat 2017 - Expedia Seattle",
+    "url": "https://www.eventbrite.com/e/global-day-of-coderetreat-expedia-seattle-tickets-38775140489"
 }

--- a/_data/events_gdcr2017/Seattle.json
+++ b/_data/events_gdcr2017/Seattle.json
@@ -1,17 +1,20 @@
 {
-  "title": "Global Day of Code Retreat 2017 - Seattle",
-  "url": "http://bit.ly/gdcr17seattle",
-  "moderators": [
-    "@oshoukry"
-  ],
-  "location": {
-    "city": "Seattle",
-    "country": "United States of America",
-    "coordinates": {
-      "latitude": 47.5971153,
-      "longitude": -122.3285467
+    "location": {
+        "city": "Seattle",
+        "coordinates": {
+            "latitude": 47.5971153,
+            "longitude": -122.3285467
+        },
+        "country": "United States of America",
+        "timezone": "America/Los_Angeles",
+        "utcOffset": -7
     },
-    "utcOffset": -7,
-    "timezone": "America/Los_Angeles"
-  }
+    "moderators": [
+        {
+            "name": "Oz",
+            "url": "https://twitter.com/oshoukry"
+        }
+    ],
+    "title": "Global Day of Code Retreat 2017 - Seattle",
+    "url": "http://bit.ly/gdcr17seattle"
 }

--- a/_data/events_gdcr2017/Shanghai.json
+++ b/_data/events_gdcr2017/Shanghai.json
@@ -1,19 +1,26 @@
 {
-  "title": "GDCR17 in Shanghai",
-  "url": "https://jinshuju.net/f/0UG5uv",
-  "moderators": [
-    "@FengxiangZhu",
-    "Wu Ke",
-    "Jin Zhonghao"
-  ],
-  "location": {
-    "city": "Shanghai",
-    "country": "China",
-    "coordinates": {
-      "latitude": 31.224631,
-      "longitude": 121.1958828
+    "location": {
+        "city": "Shanghai",
+        "coordinates": {
+            "latitude": 31.224631,
+            "longitude": 121.1958828
+        },
+        "country": "China",
+        "timezone": "Asia/Shanghai",
+        "utcOffset": 8
     },
-    "utcOffset": 8,
-    "timezone": "Asia/Shanghai"
-  }
+    "moderators": [
+        {
+            "name": "@FengxiangZhu",
+            "url": "https://twitter.com/FengxiangZhu"
+        },
+        {
+            "name": "Wu Ke"
+        },
+        {
+            "name": "Jin Zhonghao"
+        }
+    ],
+    "title": "GDCR17 in Shanghai",
+    "url": "https://jinshuju.net/f/0UG5uv"
 }

--- a/_data/events_gdcr2017/Sofia.json
+++ b/_data/events_gdcr2017/Sofia.json
@@ -1,18 +1,23 @@
 {
-  "title": "Global Day of Coderetreat in Sofia",
-  "url": "https://www.eventbrite.com/e/global-day-of-coderetreat-2017-tickets-39040657658",
-  "moderators": [
-    "@KaloyanPetrovOG",
-    "Desislava Ivanovich"
-  ],
-  "location": {
-    "city": "Sofia",
-    "country": "Bulgaria",
-    "coordinates": {
-      "latitude": 42.700671,
-      "longitude": 23.306263
+    "location": {
+        "city": "Sofia",
+        "coordinates": {
+            "latitude": 42.700671,
+            "longitude": 23.306263
+        },
+        "country": "Bulgaria",
+        "timezone": "Europe/Sofia",
+        "utcOffset": 3
     },
-    "utcOffset": 3,
-    "timezone": "Europe/Sofia"
-  }
+    "moderators": [
+        {
+            "name": "Kaloyan Petrov",
+            "url": "https://twitter.com/KaloyanPetrovOG"
+        },
+        {
+            "name": "Desislava Ivanovich"
+        }
+    ],
+    "title": "Global Day of Coderetreat in Sofia",
+    "url": "https://www.eventbrite.com/e/global-day-of-coderetreat-2017-tickets-39040657658"
 }

--- a/_data/events_gdcr2017/SophiaAntipolis.json
+++ b/_data/events_gdcr2017/SophiaAntipolis.json
@@ -1,17 +1,20 @@
 {
-  "title": "GDRC17 in Sophia Antipolis",
-  "url": "https://www.eventbrite.fr/e/billets-global-day-of-code-retreat-a-polytechnice-39340819450",
-  "moderators": [
-    "@mosser"
-  ],
-  "location": {
-    "city": "Sophia Antipolis",
-    "country": "France",
-    "coordinates": {
-      "latitude": 43.614738,
-      "longitude": 7.071720
+    "location": {
+        "city": "Sophia Antipolis",
+        "coordinates": {
+            "latitude": 43.614738,
+            "longitude": 7.07172
+        },
+        "country": "France",
+        "timezone": "Europe/Paris",
+        "utcOffset": 2
     },
-    "utcOffset": 2,
-    "timezone": "Europe/Paris"
-  }
+    "moderators": [
+        {
+            "name": "\u307e\u3063\u3061\u3083\u3093",
+            "url": "https://twitter.com/mosser"
+        }
+    ],
+    "title": "GDRC17 in Sophia Antipolis",
+    "url": "https://www.eventbrite.fr/e/billets-global-day-of-code-retreat-a-polytechnice-39340819450"
 }

--- a/_data/events_gdcr2017/Stockholm.json
+++ b/_data/events_gdcr2017/Stockholm.json
@@ -1,21 +1,29 @@
 {
-  "title": "GDCR17 in Stockholm",
-  "url": "https://www.meetup.com/Stockholm-Software-Craftsmanship/events/244834081/",
-  "moderators": [
-    "@erorcodes",
-    "Stockholm Software Craftsmanship"
-  ],
-  "sponsors": [
-    "@citerus_se"
-  ],
-  "location": {
-    "city": "Stockholm",
-    "country": "Sweden",
-    "coordinates": {
-      "latitude": 59.3359476,
-      "longitude": 18.0533043
+    "location": {
+        "city": "Stockholm",
+        "coordinates": {
+            "latitude": 59.3359476,
+            "longitude": 18.0533043
+        },
+        "country": "Sweden",
+        "timezone": "Europe/Stockholm",
+        "utcOffset": 2
     },
-    "utcOffset": 2,
-    "timezone": "Europe/Stockholm"
-  }
+    "moderators": [
+        {
+            "name": "Erika Ornstein",
+            "url": "https://twitter.com/erorcodes"
+        },
+        {
+            "name": "Stockholm Software Craftsmanship"
+        }
+    ],
+    "sponsors": [
+        {
+            "name": "Citerus",
+            "url": "https://twitter.com/citerus_se"
+        }
+    ],
+    "title": "GDCR17 in Stockholm",
+    "url": "https://www.meetup.com/Stockholm-Software-Craftsmanship/events/244834081/"
 }

--- a/_data/events_gdcr2017/Sydney.json
+++ b/_data/events_gdcr2017/Sydney.json
@@ -1,19 +1,25 @@
 {
-  "title": "GDCR Sydney @ Pivotal Labs",
-  "url": "https://www.meetup.com/PivotalSydney-Tech-Talks/events/244264081/",
-  "moderators": [
-    "Dariusz Lorenc",
-    "Federico Lopez Laborda",
-    "Peter Huynh"
-  ],
-  "location": {
-    "city": "Sydney",
-    "country": "Australia",
-    "coordinates": {
-      "latitude": -33.8679919,
-      "longitude": 151.2049818
+    "location": {
+        "city": "Sydney",
+        "coordinates": {
+            "latitude": -33.8679919,
+            "longitude": 151.2049818
+        },
+        "country": "Australia",
+        "timezone": "Australia/Sydney",
+        "utcOffset": 10
     },
-    "utcOffset": 10,
-    "timezone": "Australia/Sydney"
-  }
+    "moderators": [
+        {
+            "name": "Dariusz Lorenc"
+        },
+        {
+            "name": "Federico Lopez Laborda"
+        },
+        {
+            "name": "Peter Huynh"
+        }
+    ],
+    "title": "GDCR Sydney @ Pivotal Labs",
+    "url": "https://www.meetup.com/PivotalSydney-Tech-Talks/events/244264081/"
 }

--- a/_data/events_gdcr2017/TEMPLATE
+++ b/_data/events_gdcr2017/TEMPLATE
@@ -1,15 +1,24 @@
 {
-  "title": "GDCR17 in Berlin",
-  "url": "https://www.meetup.com/Software-Craftsmanship-Berlin/",
-  "location": {
-    "utcOffset": 2,
-    "timezone": "Europe/Berlin",
-    "city": "Berlin",
-    "country": "Germany",
-    "coordinates": {
-      "latitude": 52.5250871,
-      "longitude": 13.3672133
-    }
-  },
-  "moderators": ["@moderator1", "@moderator2"]
+    "location": {
+        "city": "Berlin",
+        "coordinates": {
+            "latitude": 52.5250871,
+            "longitude": 13.3672133
+        },
+        "country": "Germany",
+        "timezone": "Europe/Berlin",
+        "utcOffset": 2
+    },
+    "moderators": [
+        {
+            "name": "Super Vegas Slots",
+            "url": "https://twitter.com/moderator1"
+        },
+        {
+            "name": "Moderator",
+            "url": "https://twitter.com/moderator2"
+        }
+    ],
+    "title": "GDCR17 in Berlin",
+    "url": "https://www.meetup.com/Software-Craftsmanship-Berlin/"
 }

--- a/_data/events_gdcr2017/Thessaloniki.json
+++ b/_data/events_gdcr2017/Thessaloniki.json
@@ -1,17 +1,20 @@
 {
-  "title": "GDCR in Thessaloniki",
-  "url": "http://coderetreat.gr",
-  "moderators": [
-    "@softwaregarden"
-  ],
-  "location": {
-    "city": "Thessaloniki",
-    "country": "Greece",
-    "coordinates": {
-      "latitude": 40.6211912,
-      "longitude": 22.9284748
+    "location": {
+        "city": "Thessaloniki",
+        "coordinates": {
+            "latitude": 40.6211912,
+            "longitude": 22.9284748
+        },
+        "country": "Greece",
+        "timezone": "Europe/Athens",
+        "utcOffset": 3
     },
-    "utcOffset": 3,
-    "timezone": "Europe/Athens"
-  }
+    "moderators": [
+        {
+            "name": "Software Gardener",
+            "url": "https://twitter.com/softwaregarden"
+        }
+    ],
+    "title": "GDCR in Thessaloniki",
+    "url": "http://coderetreat.gr"
 }

--- a/_data/events_gdcr2017/Toulouse.json
+++ b/_data/events_gdcr2017/Toulouse.json
@@ -1,18 +1,24 @@
 {
-  "title": "GDCR Toulouse 2017 at Ekito",
-  "url": "https://www.meetup.com/Software-Craftsmanship-Toulouse/events/244992314/",
-  "moderators": [
-    "@superbob56",
-    "@Gaspard_PO"
-  ],
-  "location": {
-    "city": "Toulouse",
-    "country": "France",
-    "coordinates": {
-      "latitude": 43.605988,
-      "longitude": 1.452122
+    "location": {
+        "city": "Toulouse",
+        "coordinates": {
+            "latitude": 43.605988,
+            "longitude": 1.452122
+        },
+        "country": "France",
+        "timezone": "Europe/Paris",
+        "utcOffset": 2
     },
-    "utcOffset": 2,
-    "timezone": "Europe/Paris"
-  }
+    "moderators": [
+        {
+            "name": "Florian Morgan",
+            "url": "https://twitter.com/superbob56"
+        },
+        {
+            "name": "Gaspard",
+            "url": "https://twitter.com/Gaspard_PO"
+        }
+    ],
+    "title": "GDCR Toulouse 2017 at Ekito",
+    "url": "https://www.meetup.com/Software-Craftsmanship-Toulouse/events/244992314/"
 }

--- a/_data/events_gdcr2017/Turku.json
+++ b/_data/events_gdcr2017/Turku.json
@@ -1,17 +1,20 @@
 {
-  "title": "GDCR17 in Turku",
-  "url": "http://www.arado.fi/gdcr",
-  "moderators": [
-    "@rinkkasatiainen"
-  ],
-  "location": {
-    "city": "Turku",
-    "country": "Finland",
-    "coordinates": {
-      "latitude": 60.44992,
-      "longitude": 22.293958
+    "location": {
+        "city": "Turku",
+        "coordinates": {
+            "latitude": 60.44992,
+            "longitude": 22.293958
+        },
+        "country": "Finland",
+        "timezone": "Europe/Helsinki",
+        "utcOffset": 3
     },
-    "utcOffset": 3,
-    "timezone": "Europe/Helsinki"
-  }
+    "moderators": [
+        {
+            "name": "Aki Salmi",
+            "url": "https://twitter.com/rinkkasatiainen"
+        }
+    ],
+    "title": "GDCR17 in Turku",
+    "url": "http://www.arado.fi/gdcr"
 }

--- a/_data/events_gdcr2017/Urbino.json
+++ b/_data/events_gdcr2017/Urbino.json
@@ -1,18 +1,24 @@
 {
-  "title": "GDCR17 @ Italian Agile Day",
-  "url": "https://tickets.agilemovement.it/event/iad2017cr/",
-  "moderators": [
-    "@racingDeveloper",
-    "@xpmatteo"
-  ],
-  "location": {
-    "city": "Urbino",
-    "country": "Italy",
-    "coordinates": {
-      "latitude": 43.7292325,
-      "longitude": 12.6129106
+    "location": {
+        "city": "Urbino",
+        "coordinates": {
+            "latitude": 43.7292325,
+            "longitude": 12.6129106
+        },
+        "country": "Italy",
+        "timezone": "Europe/Rome",
+        "utcOffset": 2
     },
-    "utcOffset": 2,
-    "timezone": "Europe/Rome"
-  }
+    "moderators": [
+        {
+            "name": "Gabriele Tondi",
+            "url": "https://twitter.com/racingDeveloper"
+        },
+        {
+            "name": "Matteo Vaccari",
+            "url": "https://twitter.com/xpmatteo"
+        }
+    ],
+    "title": "GDCR17 @ Italian Agile Day",
+    "url": "https://tickets.agilemovement.it/event/iad2017cr/"
 }

--- a/_data/events_gdcr2017/Utrecht.json
+++ b/_data/events_gdcr2017/Utrecht.json
@@ -1,22 +1,33 @@
 {
-  "title": "Global Day of Code Retreat - Utrecht 2017",
-  "url": "https://www.meetup.com/Utrecht-Java-User-Group/events/243847568/",
-  "moderators": [
-    "@ThodorisBais",
-    "@pvdissel",
-    "Joost Baas"
-  ],
-  "sponsors": [
-    "@bol_com"
-  ],
-  "location": {
-    "city": "Utrecht",
-    "country": "Netherlands",
-    "coordinates": {
-      "latitude": 52.0907,
-      "longitude": 5.1214
+    "location": {
+        "city": "Utrecht",
+        "coordinates": {
+            "latitude": 52.0907,
+            "longitude": 5.1214
+        },
+        "country": "Netherlands",
+        "timezone": "Europe/Amsterdam",
+        "utcOffset": 2
     },
-    "utcOffset": 2,
-    "timezone": "Europe/Amsterdam"
-  }
+    "moderators": [
+        {
+            "name": "Thodoris Bais",
+            "url": "https://twitter.com/ThodorisBais"
+        },
+        {
+            "name": "Patrick",
+            "url": "https://twitter.com/pvdissel"
+        },
+        {
+            "name": "Joost Baas"
+        }
+    ],
+    "sponsors": [
+        {
+            "name": "bol.com",
+            "url": "https://twitter.com/bol_com"
+        }
+    ],
+    "title": "Global Day of Code Retreat - Utrecht 2017",
+    "url": "https://www.meetup.com/Utrecht-Java-User-Group/events/243847568/"
 }

--- a/_data/events_gdcr2017/Utsunomiya.json
+++ b/_data/events_gdcr2017/Utsunomiya.json
@@ -1,18 +1,24 @@
 {
-  "title": "Global Day of Coderetreat 2017 in Utsunomiya",
-  "url": "https://agile-no-wa-tochigi.connpass.com/event/68780/",
-  "moderators": [
-    "@sasakendayo",
-    "@Masatoshi__Endo"
-  ],
-  "location": {
-    "city": "Utsunomiya",
-    "country": "Japan",
-    "coordinates": {
-      "latitude": 36.5594479,
-      "longitude": 139.8804156
+    "location": {
+        "city": "Utsunomiya",
+        "coordinates": {
+            "latitude": 36.5594479,
+            "longitude": 139.8804156
+        },
+        "country": "Japan",
+        "timezone": "Asia/Tokyo",
+        "utcOffset": 9
     },
-    "utcOffset": 9,
-    "timezone": "Asia/Tokyo"
-  }
+    "moderators": [
+        {
+            "name": "sasakendayo",
+            "url": "https://twitter.com/sasakendayo"
+        },
+        {
+            "name": "masatoshi endo",
+            "url": "https://twitter.com/Masatoshi__Endo"
+        }
+    ],
+    "title": "Global Day of Coderetreat 2017 in Utsunomiya",
+    "url": "https://agile-no-wa-tochigi.connpass.com/event/68780/"
 }

--- a/_data/events_gdcr2017/Vadodara.json
+++ b/_data/events_gdcr2017/Vadodara.json
@@ -1,17 +1,20 @@
 {
-  "title": "GDCR 2017 Vadodara",
-  "url": "https://www.meetup.com/JUG-Vadodara/events/244813435/",
-  "moderators": [
-    "@CsiVadodara"
-  ],
-  "location": {
-    "city": "Vadodara",
-    "country": "India",
-    "coordinates": {
-      "latitude": 22.32,
-      "longitude": 73.03
+    "location": {
+        "city": "Vadodara",
+        "coordinates": {
+            "latitude": 22.32,
+            "longitude": 73.03
+        },
+        "country": "India",
+        "timezone": "Asia/Kolkata",
+        "utcOffset": 5.5
     },
-    "utcOffset": 5.5,
-    "timezone": "Asia/Kolkata"
-  }
+    "moderators": [
+        {
+            "name": "CSI Vadodara",
+            "url": "https://twitter.com/CsiVadodara"
+        }
+    ],
+    "title": "GDCR 2017 Vadodara",
+    "url": "https://www.meetup.com/JUG-Vadodara/events/244813435/"
 }

--- a/_data/events_gdcr2017/Valencia.json
+++ b/_data/events_gdcr2017/Valencia.json
@@ -1,20 +1,26 @@
 {
-  "title": "Global Day of Coderetreat 2017 in Valencia",
-  "url": "https://www.meetup.com/es-ES/Aprende-a-programar-en-Valencia/events/244747810/",
-  "moderators": [
-    "@devscola"
-  ],
-  "sponsors": [
-    "@FlywireEng"
-  ],
-  "location": {
-    "city": "Valencia",
-    "country": "Spain",
-    "coordinates": {
-      "latitude": 39.4699,
-      "longitude": 0.3763
+    "location": {
+        "city": "Valencia",
+        "coordinates": {
+            "latitude": 39.4699,
+            "longitude": 0.3763
+        },
+        "country": "Spain",
+        "timezone": "Europe/Madrid",
+        "utcOffset": 2
     },
-    "utcOffset": 2,
-    "timezone": "Europe/Madrid"
-  }
+    "moderators": [
+        {
+            "name": "devscola",
+            "url": "https://twitter.com/devscola"
+        }
+    ],
+    "sponsors": [
+        {
+            "name": "Flywire Engineering",
+            "url": "https://twitter.com/FlywireEng"
+        }
+    ],
+    "title": "Global Day of Coderetreat 2017 in Valencia",
+    "url": "https://www.meetup.com/es-ES/Aprende-a-programar-en-Valencia/events/244747810/"
 }

--- a/_data/events_gdcr2017/Vienna.json
+++ b/_data/events_gdcr2017/Vienna.json
@@ -1,18 +1,24 @@
 {
-  "title": "GDCR17 in Vienna, Austria",
-  "url": "https://techtalk.at/trainings/global-day-of-coderetreat-2017/?lang=en",
-  "moderators": [
-    "@emilybache",
-    "@codecopkofler"
-  ],
-  "location": {
-    "city": "Vienna",
-    "country": "Austria",
-    "coordinates": {
-      "latitude": 48.23645,
-      "longitude": 16.413294
+    "location": {
+        "city": "Vienna",
+        "coordinates": {
+            "latitude": 48.23645,
+            "longitude": 16.413294
+        },
+        "country": "Austria",
+        "timezone": "Europe/Vienna",
+        "utcOffset": 2
     },
-    "utcOffset": 2,
-    "timezone": "Europe/Vienna"
-  }
+    "moderators": [
+        {
+            "name": "Emily Bache",
+            "url": "https://twitter.com/emilybache"
+        },
+        {
+            "name": "Peter Kofler",
+            "url": "https://twitter.com/codecopkofler"
+        }
+    ],
+    "title": "GDCR17 in Vienna, Austria",
+    "url": "https://techtalk.at/trainings/global-day-of-coderetreat-2017/?lang=en"
 }

--- a/_data/events_gdcr2017/Vilnius.json
+++ b/_data/events_gdcr2017/Vilnius.json
@@ -1,16 +1,19 @@
 {
-  "title": "GDCR17 in Vilnius",
-  "url": "http://global-day-of-coderetreat-vilnius-2017.eventbrite.com",
-  "moderators": [
-    "@ogrigas"
-  ],
-  "location": {
-    "city": "Vilnius",
-    "country": "Lithuania",
-    "coordinates": {
-    	"latitude": 54.687157,
-    	"longitude": 25.279652
+    "location": {
+        "city": "Vilnius",
+        "coordinates": {
+            "latitude": 54.687157,
+            "longitude": 25.279652
+        },
+        "country": "Lithuania",
+        "timezone": "Europe/Vilnius"
     },
-    "timezone": "Europe/Vilnius"
-  }
+    "moderators": [
+        {
+            "name": "Osvaldas Grigas",
+            "url": "https://twitter.com/ogrigas"
+        }
+    ],
+    "title": "GDCR17 in Vilnius",
+    "url": "http://global-day-of-coderetreat-vilnius-2017.eventbrite.com"
 }

--- a/_data/events_gdcr2017/Wasquehal.json
+++ b/_data/events_gdcr2017/Wasquehal.json
@@ -1,19 +1,28 @@
 {
-  "title": "GDCR2017 in AXA Web Center",
-  "url": "https://www.meetup.com/fr-FR/Nord-agile/events/244762252/",
-  "moderators": [
-    "@ImenNecibRassaa",
-    "@xavierballoy",
-    "@ToF_"
-  ],
-  "location": {
-    "city": "Wasquehal",
-    "country": "France",
-    "coordinates": {
-      "latitude": 50.681279,
-      "longitude": 3.117162
+    "location": {
+        "city": "Wasquehal",
+        "coordinates": {
+            "latitude": 50.681279,
+            "longitude": 3.117162
+        },
+        "country": "France",
+        "timezone": "Europe/Paris",
+        "utcOffset": 2
     },
-    "utcOffset": 2,
-    "timezone": "Europe/Paris"
-  }
+    "moderators": [
+        {
+            "name": "NECIB RASSAA Imen",
+            "url": "https://twitter.com/ImenNecibRassaa"
+        },
+        {
+            "name": "Xavier Balloy",
+            "url": "https://twitter.com/xavierballoy"
+        },
+        {
+            "name": "Christophe Thibaut",
+            "url": "https://twitter.com/ToF_"
+        }
+    ],
+    "title": "GDCR2017 in AXA Web Center",
+    "url": "https://www.meetup.com/fr-FR/Nord-agile/events/244762252/"
 }

--- a/_data/events_gdcr2017/Winnipeg-ACE.json
+++ b/_data/events_gdcr2017/Winnipeg-ACE.json
@@ -1,18 +1,24 @@
 {
-  "title": "ACE Code Retreat ",
-  "url": "https://www.eventbrite.ca/e/ace-code-retreat-tickets-39210306081",
-  "moderators": [
-    "@stungeye",
-    "@bernardic"
-  ],
-  "location": {
-    "city": "Winnipeg",
-    "country": "Canada",
-    "coordinates": {
-      "latitude": 49.898438,
-      "longitude": -97.1462603
+    "location": {
+        "city": "Winnipeg",
+        "coordinates": {
+            "latitude": 49.898438,
+            "longitude": -97.1462603
+        },
+        "country": "Canada",
+        "timezone": "America/Winnipeg",
+        "utcOffset": -5
     },
-    "utcOffset": -5,
-    "timezone": "America/Winnipeg"
-  }
+    "moderators": [
+        {
+            "name": "Kyle Geske",
+            "url": "https://twitter.com/stungeye"
+        },
+        {
+            "name": "Dan Bernardic",
+            "url": "https://twitter.com/bernardic"
+        }
+    ],
+    "title": "ACE Code Retreat ",
+    "url": "https://www.eventbrite.ca/e/ace-code-retreat-tickets-39210306081"
 }

--- a/_data/events_gdcr2017/Wroclaw.json
+++ b/_data/events_gdcr2017/Wroclaw.json
@@ -1,17 +1,20 @@
 {
-  "title": "Global Day of Coderetreat 2017 Wroclaw",
-  "url": "https://softwaretalks.pl/wydarzenia/global-day-coderetreat/",
-  "moderators": [
-    "@b_rodak"
-  ],
-  "location": {
-    "city": "Wroclaw",
-    "country": "Poland",
-    "coordinates": {
-      "latitude": 51.0967185,
-      "longitude": 17.0319457
+    "location": {
+        "city": "Wroclaw",
+        "coordinates": {
+            "latitude": 51.0967185,
+            "longitude": 17.0319457
+        },
+        "country": "Poland",
+        "timezone": "Europe/Warsaw",
+        "utcOffset": 2
     },
-    "utcOffset": 2,
-    "timezone": "Europe/Warsaw"
-  }
+    "moderators": [
+        {
+            "name": "Bart\u0142omiej Rodak",
+            "url": "https://twitter.com/b_rodak"
+        }
+    ],
+    "title": "Global Day of Coderetreat 2017 Wroclaw",
+    "url": "https://softwaretalks.pl/wydarzenia/global-day-coderetreat/"
 }

--- a/_data/events_gdcr2017/Zaragoza.json
+++ b/_data/events_gdcr2017/Zaragoza.json
@@ -1,17 +1,20 @@
 {
-    "title": "Global day of Code Retreat 2017 in Zaragoza",
-    "url": "https://www.meetup.com/es-ES/agilearagon/events/244698186/?eventId=244698186",
-    "moderators": [
-      "@AgileAragon"
-    ],
     "location": {
-      "city": "Zaragoza",
-      "country": "Spain",
-      "coordinates": {
-        "latitude": 41.670584,
-        "longitude": -0.901738
-      },
-      "utcOffset": 2,
-      "timezone": "Europe/Madrid"
-    }
-  }
+        "city": "Zaragoza",
+        "coordinates": {
+            "latitude": 41.670584,
+            "longitude": -0.901738
+        },
+        "country": "Spain",
+        "timezone": "Europe/Madrid",
+        "utcOffset": 2
+    },
+    "moderators": [
+        {
+            "name": "AgileAragon",
+            "url": "https://twitter.com/AgileAragon"
+        }
+    ],
+    "title": "Global day of Code Retreat 2017 in Zaragoza",
+    "url": "https://www.meetup.com/es-ES/agilearagon/events/244698186/?eventId=244698186"
+}

--- a/_data/events_gdcr2017/Zielona-Gora.json
+++ b/_data/events_gdcr2017/Zielona-Gora.json
@@ -1,17 +1,19 @@
 {
-  "title": "GDCR 2017 in Zielona Gora",
-  "url": "https://goo.gl/forms/7pbu06DwCfZhrdNc2",
-  "moderators": [
-    "Jakub Szpak"
-  ],
-  "location": {
-    "city": "Zielona Gora",
-    "country": "Poland",
-    "coordinates": {
-      "latitude": 51.942083,
-      "longitude": 15.5279537
+    "location": {
+        "city": "Zielona Gora",
+        "coordinates": {
+            "latitude": 51.942083,
+            "longitude": 15.5279537
+        },
+        "country": "Poland",
+        "timezone": "Europe/Warsaw",
+        "utcOffset": 2
     },
-    "utcOffset": 2,
-    "timezone": "Europe/Warsaw"
-  }
+    "moderators": [
+        {
+            "name": "Jakub Szpak"
+        }
+    ],
+    "title": "GDCR 2017 in Zielona Gora",
+    "url": "https://goo.gl/forms/7pbu06DwCfZhrdNc2"
 }

--- a/_data/events_gdcr2017/Zurich.json
+++ b/_data/events_gdcr2017/Zurich.json
@@ -1,17 +1,20 @@
 {
-    "title": "GDCR17 in Zurich",
-    "url": "http://zurich.codersonly.org/events/code-retreat/",
-    "moderators": [
-        "@infinitary"
-    ],
     "location": {
-        "city": "Zürich",
-        "country": "Switzerland",
+        "city": "Z\u00fcrich",
         "coordinates": {
             "latitude": 47.36459,
             "longitude": 8.53156
         },
-        "utcOffset": 2,
-        "timezone": "Europe/Zurich"
-    }
+        "country": "Switzerland",
+        "timezone": "Europe/Zurich",
+        "utcOffset": 2
+    },
+    "moderators": [
+        {
+            "name": "i'm too meta for my shirt",
+            "url": "https://twitter.com/infinitary"
+        }
+    ],
+    "title": "GDCR17 in Zurich",
+    "url": "http://zurich.codersonly.org/events/code-retreat/"
 }

--- a/_data/events_gdcr2017/atlanta.json
+++ b/_data/events_gdcr2017/atlanta.json
@@ -1,17 +1,20 @@
 {
-  "title": "GDCR 2017 in Atlanta",
-  "url": "http://www.coderetreatatl.com/",
-  "moderators": [
-    "@mdclement"
-  ],
-  "location": {
-    "city": "Atlanta, GA",
-    "country": "USA",
-    "coordinates": {
-      "latitude": 33.807474,
-      "longitude": -84.3829214
+    "location": {
+        "city": "Atlanta, GA",
+        "coordinates": {
+            "latitude": 33.807474,
+            "longitude": -84.3829214
+        },
+        "country": "USA",
+        "timezone": "America/New_York",
+        "utcOffset": -4
     },
-    "utcOffset": -4,
-    "timezone": "America/New_York"
-  }
+    "moderators": [
+        {
+            "name": "Mike Clement",
+            "url": "https://twitter.com/mdclement"
+        }
+    ],
+    "title": "GDCR 2017 in Atlanta",
+    "url": "http://www.coderetreatatl.com/"
 }

--- a/_data/events_gdcr2017/bielefeld.json
+++ b/_data/events_gdcr2017/bielefeld.json
@@ -1,17 +1,19 @@
 {
-  "title": "GDCR17 in Bielefeld",
-  "url": "https://www.softwerkskammer.org/activities/mob-gdcr-17",
-  "moderators": [
-    "Jaroslaw Klose"
-  ],
-  "location": {
-    "city": "Bielefeld",
-    "country": "Germany",
-    "coordinates": {
-      "latitude": 52.0426848,
-      "longitude": 8.4906118
+    "location": {
+        "city": "Bielefeld",
+        "coordinates": {
+            "latitude": 52.0426848,
+            "longitude": 8.4906118
+        },
+        "country": "Germany",
+        "timezone": "Europe/Berlin",
+        "utcOffset": 2
     },
-    "utcOffset": 2,
-    "timezone": "Europe/Berlin"
-  }
+    "moderators": [
+        {
+            "name": "Jaroslaw Klose"
+        }
+    ],
+    "title": "GDCR17 in Bielefeld",
+    "url": "https://www.softwerkskammer.org/activities/mob-gdcr-17"
 }

--- a/_data/events_gdcr2017/bonn.json
+++ b/_data/events_gdcr2017/bonn.json
@@ -1,13 +1,15 @@
 {
-  "title": "Global Day Of Code Retreat at itemis Bonn",
-  "url": "https://www.meetup.com/de-DE/preview/itemis/events/244448511",
-  "moderators": [
-    "Olaf Gunkel"
-  ],
-  "location": {
-    "city": "Bonn",
-    "country": "Germany",
-    "utcOffset": 2,
-    "timezone": "Europe/Berlin"
-  }
+    "location": {
+        "city": "Bonn",
+        "country": "Germany",
+        "timezone": "Europe/Berlin",
+        "utcOffset": 2
+    },
+    "moderators": [
+        {
+            "name": "Olaf Gunkel"
+        }
+    ],
+    "title": "Global Day Of Code Retreat at itemis Bonn",
+    "url": "https://www.meetup.com/de-DE/preview/itemis/events/244448511"
 }

--- a/_data/events_gdcr2017/cologne.json
+++ b/_data/events_gdcr2017/cologne.json
@@ -1,17 +1,20 @@
 {
-  "title": "Global Day of Code Retreat 2017 @lisegmbh in Cologne",
-  "url": "http://bit.ly/gdcr-2017-cologne",
-  "moderators": [
-    "@skorzinetzki"
-  ],
-  "location": {
-    "city": "Cologne",
-    "country": "Germany",
-    "coordinates": {
-      "latitude": 50.9847388,
-      "longitude": 6.8879454
+    "location": {
+        "city": "Cologne",
+        "coordinates": {
+            "latitude": 50.9847388,
+            "longitude": 6.8879454
+        },
+        "country": "Germany",
+        "timezone": "Europe/Berlin",
+        "utcOffset": 2
     },
-    "utcOffset": 2,
-    "timezone": "Europe/Berlin"
-  }
+    "moderators": [
+        {
+            "name": "Steve Korzinetzki",
+            "url": "https://twitter.com/skorzinetzki"
+        }
+    ],
+    "title": "Global Day of Code Retreat 2017 @lisegmbh in Cologne",
+    "url": "http://bit.ly/gdcr-2017-cologne"
 }

--- a/_data/events_gdcr2017/frankfurt.json
+++ b/_data/events_gdcr2017/frankfurt.json
@@ -1,18 +1,24 @@
 {
-  "title": "Global Day of Coderetreat 2017",
-  "url": "https://www.meetup.com/de-DE/Software-Craftsmanship-Rhein-Main/events/241598168/",
-  "moderators": [
-    "@svenlange",
-    "@CodeRetreatFfm"
-  ],
-  "location": {
-    "city": "Frankfurt",
-    "country": "Germany",
-    "coordinates": {
-      "latitude": 50.1213475,
-      "longitude": 8.4961386
+    "location": {
+        "city": "Frankfurt",
+        "coordinates": {
+            "latitude": 50.1213475,
+            "longitude": 8.4961386
+        },
+        "country": "Germany",
+        "timezone": "Europe/Berlin",
+        "utcOffset": 2
     },
-    "utcOffset": 2,
-    "timezone": "Europe/Berlin"
-  }
+    "moderators": [
+        {
+            "name": "Sven Lange",
+            "url": "https://twitter.com/svenlange"
+        },
+        {
+            "name": "CodeRetreat Rhein-Ma",
+            "url": "https://twitter.com/CodeRetreatFfm"
+        }
+    ],
+    "title": "Global Day of Coderetreat 2017",
+    "url": "https://www.meetup.com/de-DE/Software-Craftsmanship-Rhein-Main/events/241598168/"
 }

--- a/_data/events_gdcr2017/frankfurtAmMain.json
+++ b/_data/events_gdcr2017/frankfurtAmMain.json
@@ -1,17 +1,20 @@
 {
-  "title": "GDCR 17 in Frankfurt am Main @itemis ",
-  "url": "https://www.eventbrite.de/e/global-day-of-coderetreat-2017-in-frankfurt-tickets-37800982757",
-  "moderators": [
-    "@MAliKazmi12"
-  ],
-  "location": {
-    "city": "Frankfurt am Main",
-    "country": "Germany",
-    "coordinates": {
-      "latitude": 50.1128534,
-      "longitude": 8.6601713
+    "location": {
+        "city": "Frankfurt am Main",
+        "coordinates": {
+            "latitude": 50.1128534,
+            "longitude": 8.6601713
+        },
+        "country": "Germany",
+        "timezone": "Europe/Berlin",
+        "utcOffset": 2
     },
-    "utcOffset": 2,
-    "timezone": "Europe/Berlin"
-  }
+    "moderators": [
+        {
+            "name": "Muhammad Ali Kazmi",
+            "url": "https://twitter.com/MAliKazmi12"
+        }
+    ],
+    "title": "GDCR 17 in Frankfurt am Main @itemis ",
+    "url": "https://www.eventbrite.de/e/global-day-of-coderetreat-2017-in-frankfurt-tickets-37800982757"
 }

--- a/_data/events_gdcr2017/istanbul.json
+++ b/_data/events_gdcr2017/istanbul.json
@@ -1,17 +1,20 @@
 {
-  "title": "İstanbul Global Day of Code Retreat ",
-  "url": "https://www.eventbrite.com/e/istanbul-global-day-of-code-retreat-tickets-35984937918",
-  "moderators": [
-    "@tt_melih"
-  ],
-  "location": {
-    "city": "istanbul",
-    "country": "Turkey",
-    "coordinates": {
-      "latitude": 41.0799598,
-      "longitude": 29.0072429
+    "location": {
+        "city": "istanbul",
+        "coordinates": {
+            "latitude": 41.0799598,
+            "longitude": 29.0072429
+        },
+        "country": "Turkey",
+        "timezone": "Europe/Istanbul",
+        "utcOffset": 3
     },
-    "utcOffset": 3,
-    "timezone": "Europe/Istanbul"
-  }
+    "moderators": [
+        {
+            "name": "Melih.tt",
+            "url": "https://twitter.com/tt_melih"
+        }
+    ],
+    "title": "\u0130stanbul Global Day of Code Retreat ",
+    "url": "https://www.eventbrite.com/e/istanbul-global-day-of-code-retreat-tickets-35984937918"
 }

--- a/_data/events_gdcr2017/istanbul2.json
+++ b/_data/events_gdcr2017/istanbul2.json
@@ -1,19 +1,28 @@
 {
-  "title": "GDCR17 Festival at Istanbul",
-  "url": "https://www.meetup.com/Software-Craftsmanship-Turkey/events/242432406/",
-  "moderators": [
-    "@lemiorhan",
-    "@scturkey",
-    "@agileturkey"
-  ],
-  "location": {
-    "city": "Istanbul",
-    "country": "Turkey",
-    "coordinates": {
-      "latitude": 41.0285741,
-      "longitude": 29.1150436
+    "location": {
+        "city": "Istanbul",
+        "coordinates": {
+            "latitude": 41.0285741,
+            "longitude": 29.1150436
+        },
+        "country": "Turkey",
+        "timezone": "Europe/Istanbul",
+        "utcOffset": 3
     },
-    "utcOffset": 3,
-    "timezone": "Europe/Istanbul"
-  }
+    "moderators": [
+        {
+            "name": "Lemi Orhan Ergin",
+            "url": "https://twitter.com/lemiorhan"
+        },
+        {
+            "name": "SCTurkey",
+            "url": "https://twitter.com/scturkey"
+        },
+        {
+            "name": "Agile Turkey",
+            "url": "https://twitter.com/agileturkey"
+        }
+    ],
+    "title": "GDCR17 Festival at Istanbul",
+    "url": "https://www.meetup.com/Software-Craftsmanship-Turkey/events/242432406/"
 }

--- a/_data/events_gdcr2017/istanbul3.json
+++ b/_data/events_gdcr2017/istanbul3.json
@@ -1,20 +1,28 @@
 {
-  "title": "Istanbul JUG Coderetreat Etkinligi 2017",
-  "url": "https://www.meetup.com/Istanbul-Java-User-Group/events/240575967/",
-  "moderators": [
-    "Gökalp Gürbüzer",
-    "Taner Diler",
-    "Altug Bilgin Altintas",
-    "Taylan Kurt"
-  ],
-  "location": {
-    "city": "Istanbul",
-    "country": "Turkey",
-    "coordinates": {
-      "latitude": 41.0427111,
-      "longitude": 29.0069467
+    "location": {
+        "city": "Istanbul",
+        "coordinates": {
+            "latitude": 41.0427111,
+            "longitude": 29.0069467
+        },
+        "country": "Turkey",
+        "timezone": "Europe/Istanbul",
+        "utcOffset": 3
     },
-    "utcOffset": 3,
-    "timezone": "Europe/Istanbul"
-  }
+    "moderators": [
+        {
+            "name": "G\u00f6kalp G\u00fcrb\u00fczer"
+        },
+        {
+            "name": "Taner Diler"
+        },
+        {
+            "name": "Altug Bilgin Altintas"
+        },
+        {
+            "name": "Taylan Kurt"
+        }
+    ],
+    "title": "Istanbul JUG Coderetreat Etkinligi 2017",
+    "url": "https://www.meetup.com/Istanbul-Java-User-Group/events/240575967/"
 }

--- a/_data/events_gdcr2017/osnabrueck.json
+++ b/_data/events_gdcr2017/osnabrueck.json
@@ -1,20 +1,26 @@
 {
-  "title": "»Global Day of Coderetreat« 2017 in Osnabrück",
-  "url": "https://www.eventbrite.de/e/global-day-of-coderetreat-2017-in-osnabruck-tickets-38034418971",
-  "moderators": [
-    "@saschadoemer"
-  ],
-  "sponsors": [
-    "@lmisag"
-  ],
-  "location": {
-    "city": "Osnabrück",
-    "country": "Germany",
-    "coordinates": {
-      "latitude": 52.2731405,
-      "longitude": 8.0477367
+    "location": {
+        "city": "Osnabr\u00fcck",
+        "coordinates": {
+            "latitude": 52.2731405,
+            "longitude": 8.0477367
+        },
+        "country": "Germany",
+        "timezone": "Europe/Berlin",
+        "utcOffset": 2
     },
-    "utcOffset": 2,
-    "timezone": "Europe/Berlin"
-  }
+    "moderators": [
+        {
+            "name": "sascha.doemer",
+            "url": "https://twitter.com/saschadoemer"
+        }
+    ],
+    "sponsors": [
+        {
+            "name": "LMIS AG",
+            "url": "https://twitter.com/lmisag"
+        }
+    ],
+    "title": "\u00bbGlobal Day of Coderetreat\u00ab 2017 in Osnabr\u00fcck",
+    "url": "https://www.eventbrite.de/e/global-day-of-coderetreat-2017-in-osnabruck-tickets-38034418971"
 }

--- a/_data/events_gdcr2018/Akihabara.json
+++ b/_data/events_gdcr2018/Akihabara.json
@@ -1,17 +1,20 @@
 {
-  "title": "Global Day of Coderetreat 2018 in AKihabara",
-  "url": "https://minna-de-ochakai.connpass.com/event/105897/",
-  "moderators": [
-    "@sasakendayo"
-  ],
-  "location": {
-    "city": "Akihabara",
-    "country": "Japan",
-    "coordinates": {
-      "latitude": 35.698353,
-      "longitude": 139.773114
+    "location": {
+        "city": "Akihabara",
+        "coordinates": {
+            "latitude": 35.698353,
+            "longitude": 139.773114
+        },
+        "country": "Japan",
+        "timezone": "Asia/Tokyo",
+        "utcOffset": 9
     },
-    "utcOffset": 9,
-    "timezone": "Asia/Tokyo"
-  }
+    "moderators": [
+        {
+            "name": "sasakendayo",
+            "url": "https://twitter.com/sasakendayo"
+        }
+    ],
+    "title": "Global Day of Coderetreat 2018 in AKihabara",
+    "url": "https://minna-de-ochakai.connpass.com/event/105897/"
 }

--- a/_data/events_gdcr2018/Alicante.json
+++ b/_data/events_gdcr2018/Alicante.json
@@ -1,18 +1,24 @@
 {
-  "title": "Global Day of Coderetreat 2018 in Alicante",
-  "url": "https://www.eventbrite.es/e/entradas-global-day-of-coderetreat-alicante-51646778906",
-  "moderators": [
-    "@rubocoptero",
-    "@AlicanteSwCraft"
-  ],
-  "location": {
-    "city": "Alicante",
-    "country": "Spain",
-    "coordinates": {
-      "latitude": 38.3458002,
-      "longitude": -0.4852007
+    "location": {
+        "city": "Alicante",
+        "coordinates": {
+            "latitude": 38.3458002,
+            "longitude": -0.4852007
+        },
+        "country": "Spain",
+        "timezone": "Europe/Madrid",
+        "utcOffset": 2
     },
-    "utcOffset": 2,
-    "timezone": "Europe/Madrid"
-  }
+    "moderators": [
+        {
+            "name": "Rub\u00e9n Ant\u00f3n",
+            "url": "https://twitter.com/rubocoptero"
+        },
+        {
+            "name": "Software Crafters Alicante",
+            "url": "https://twitter.com/AlicanteSwCraft"
+        }
+    ],
+    "title": "Global Day of Coderetreat 2018 in Alicante",
+    "url": "https://www.eventbrite.es/e/entradas-global-day-of-coderetreat-alicante-51646778906"
 }

--- a/_data/events_gdcr2018/Almaty.json
+++ b/_data/events_gdcr2018/Almaty.json
@@ -1,20 +1,26 @@
 {
-  "title": "GDCR18 in Almaty",
-  "url": "https://events.epam.com/events/global-day-of-coderetreat-1",
-  "moderators": [
-    "@ssshogunnn"
-  ],
-  "sponsors": [
-    "@EPAMKazakhstan"
-  ],
-  "location": {
-    "city": "Almaty",
-    "country": "Kazakhstan",
-    "coordinates": {
-      "latitude": 43.2171382,
-      "longitude": 76.8040833
+    "location": {
+        "city": "Almaty",
+        "coordinates": {
+            "latitude": 43.2171382,
+            "longitude": 76.8040833
+        },
+        "country": "Kazakhstan",
+        "timezone": "Asia/Almaty",
+        "utcOffset": 6
     },
-    "utcOffset": 6,
-    "timezone": "Asia/Almaty"
-  }
+    "moderators": [
+        {
+            "name": "Anuar Nurmakanov",
+            "url": "https://twitter.com/ssshogunnn"
+        }
+    ],
+    "sponsors": [
+        {
+            "name": "EPAM Kazakhstan",
+            "url": "https://twitter.com/EPAMKazakhstan"
+        }
+    ],
+    "title": "GDCR18 in Almaty",
+    "url": "https://events.epam.com/events/global-day-of-coderetreat-1"
 }

--- a/_data/events_gdcr2018/AnnArbor.json
+++ b/_data/events_gdcr2018/AnnArbor.json
@@ -1,18 +1,24 @@
 {
-  "title": "GDCR18 Ann Arbor @ The Forge by Pillar Technology",
-  "url": "https://www.meetup.com/TechLife-Ann-Arbor/events/252821237/",
-  "moderators": [
-    "@CuriousAgilist",
-    "@jeevsOnline"
-  ],
-  "location": {
-    "city": "Ann Arbor",
-    "country": "United States of America",
-    "coordinates": {
-      "latitude": 42.279835,
-      "longitude": -83.745728
+    "location": {
+        "city": "Ann Arbor",
+        "coordinates": {
+            "latitude": 42.279835,
+            "longitude": -83.745728
+        },
+        "country": "United States of America",
+        "timezone": "America/Detroit",
+        "utcOffset": -4
     },
-    "utcOffset": -4,
-    "timezone": "America/Detroit"
-  }
+    "moderators": [
+        {
+            "name": "Bob Allen",
+            "url": "https://twitter.com/CuriousAgilist"
+        },
+        {
+            "name": "Jeeva Nadarajah",
+            "url": "https://twitter.com/jeevsOnline"
+        }
+    ],
+    "title": "GDCR18 Ann Arbor @ The Forge by Pillar Technology",
+    "url": "https://www.meetup.com/TechLife-Ann-Arbor/events/252821237/"
 }

--- a/_data/events_gdcr2018/Astana.json
+++ b/_data/events_gdcr2018/Astana.json
@@ -1,20 +1,26 @@
 {
-  "title": "GDCR18 in Astana",
-  "url": "https://events.epam.com/events/global-day-of-coderetreat-1",
-  "moderators": [
-    "@esvalukhin"
-  ],
-  "sponsors": [
-    "@EPAMKazakhstan"
-  ],
-  "location": {
-    "city": "Astana",
-    "country": "Kazakhstan",
-    "coordinates": {
-      "latitude": 51.147862,
-      "longitude": 71.3393088
+    "location": {
+        "city": "Astana",
+        "coordinates": {
+            "latitude": 51.147862,
+            "longitude": 71.3393088
+        },
+        "country": "Kazakhstan",
+        "timezone": "Asia/Almaty",
+        "utcOffset": 6
     },
-    "utcOffset": 6,
-    "timezone": "Asia/Almaty"
-  }
+    "moderators": [
+        {
+            "name": "Eugene Svalukhin",
+            "url": "https://twitter.com/esvalukhin"
+        }
+    ],
+    "sponsors": [
+        {
+            "name": "EPAM Kazakhstan",
+            "url": "https://twitter.com/EPAMKazakhstan"
+        }
+    ],
+    "title": "GDCR18 in Astana",
+    "url": "https://events.epam.com/events/global-day-of-coderetreat-1"
 }

--- a/_data/events_gdcr2018/Asturias.json
+++ b/_data/events_gdcr2018/Asturias.json
@@ -1,21 +1,36 @@
 {
-  "title": "Asturias GDCR 2018",
-  "url": "https://www.meetup.com/AsturiasHacking/events/254343807/",
-  "moderators": [
-    "@asturiashacking",
-    "@azahara_fergui",
-    "@codecoolture",
-    "@dg_suarez",
-    "@tasug0"
-  ],
-  "location": {
-    "city": "Xixón",
-    "country": "Spain",
-    "coordinates": {
-      "latitude": 43.5229224,
-      "longitude": -5.6276883
+    "location": {
+        "city": "Xix\u00f3n",
+        "coordinates": {
+            "latitude": 43.5229224,
+            "longitude": -5.6276883
+        },
+        "country": "Spain",
+        "timezone": "Europe/Madrid",
+        "utcOffset": 2
     },
-    "utcOffset": 2,
-    "timezone": "Europe/Madrid"
-  }
+    "moderators": [
+        {
+            "name": "AsturiasHacking",
+            "url": "https://twitter.com/asturiashacking"
+        },
+        {
+            "name": "Azahara Fern\u00e1ndez",
+            "url": "https://twitter.com/azahara_fergui"
+        },
+        {
+            "name": "Sergio",
+            "url": "https://twitter.com/codecoolture"
+        },
+        {
+            "name": "Diego",
+            "url": "https://twitter.com/dg_suarez"
+        },
+        {
+            "name": "Manuel G\u00f3mez",
+            "url": "https://twitter.com/tasug0"
+        }
+    ],
+    "title": "Asturias GDCR 2018",
+    "url": "https://www.meetup.com/AsturiasHacking/events/254343807/"
 }

--- a/_data/events_gdcr2018/Atlanta.json
+++ b/_data/events_gdcr2018/Atlanta.json
@@ -1,20 +1,26 @@
 {
-  "title": "GDCR 2018 in Atlanta",
-  "url": "http://www.coderetreatatl.com/",
-  "moderators": [
-    "@mdclement"
-  ],
-  "sponsors": [
-    "@thegreatersum"
-  ],
-  "location": {
-    "city": "Atlanta, GA",
-    "country": "United States of America",
-    "coordinates": {
-      "latitude": 33.807474,
-      "longitude": -84.3829214
+    "location": {
+        "city": "Atlanta, GA",
+        "coordinates": {
+            "latitude": 33.807474,
+            "longitude": -84.3829214
+        },
+        "country": "United States of America",
+        "timezone": "America/New_York",
+        "utcOffset": -4
     },
-    "utcOffset": -4,
-    "timezone": "America/New_York"
-  }
+    "moderators": [
+        {
+            "name": "Mike Clement",
+            "url": "https://twitter.com/mdclement"
+        }
+    ],
+    "sponsors": [
+        {
+            "name": "Greater Sum",
+            "url": "https://twitter.com/thegreatersum"
+        }
+    ],
+    "title": "GDCR 2018 in Atlanta",
+    "url": "http://www.coderetreatatl.com/"
 }

--- a/_data/events_gdcr2018/Auckland-Pushpay.json
+++ b/_data/events_gdcr2018/Auckland-Pushpay.json
@@ -1,20 +1,26 @@
 {
-  "title": "GDCR18 at Pushpay, Auckland",
-  "url": "https://www.meetup.com/kiwi-code-retreat/events/255546323",
-  "moderators": [
-    "@mightymuke"
-  ],
-  "sponsors": [
-    "@pushpay"
-  ],
-  "location": {
-    "city": "Auckland",
-    "country": "New Zealand",
-    "coordinates": {
-      "latitude": -36.8486838,
-      "longitude": 174.7602805
+    "location": {
+        "city": "Auckland",
+        "coordinates": {
+            "latitude": -36.8486838,
+            "longitude": 174.7602805
+        },
+        "country": "New Zealand",
+        "timezone": "Pacific/Auckland",
+        "utcOffset": 13
     },
-    "utcOffset": 13,
-    "timezone": "Pacific/Auckland"
-  }
+    "moderators": [
+        {
+            "name": "Marcus Bristol",
+            "url": "https://twitter.com/mightymuke"
+        }
+    ],
+    "sponsors": [
+        {
+            "name": "Pushpay",
+            "url": "https://twitter.com/pushpay"
+        }
+    ],
+    "title": "GDCR18 at Pushpay, Auckland",
+    "url": "https://www.meetup.com/kiwi-code-retreat/events/255546323"
 }

--- a/_data/events_gdcr2018/Bangalore.json
+++ b/_data/events_gdcr2018/Bangalore.json
@@ -1,18 +1,23 @@
 {
-  "title": "GDCR@ExpertTalks",
-  "url": "https://www.meetup.com/Experttalks-bengaluru/",
-  "moderators": [
-    "@vbhagath",
-    "Prathap Reddy"
-  ],
-  "location": {
-    "city": "Bangalore",
-    "country": "India",
-    "coordinates": {
-      "latitude": 12.9564548,
-      "longitude": 77.6394432
+    "location": {
+        "city": "Bangalore",
+        "coordinates": {
+            "latitude": 12.9564548,
+            "longitude": 77.6394432
+        },
+        "country": "India",
+        "timezone": "Asia/Kolkata",
+        "utcOffset": 5.5
     },
-    "utcOffset": 5.5,
-    "timezone": "Asia/Kolkata"
-  }
+    "moderators": [
+        {
+            "name": "Vishwas",
+            "url": "https://twitter.com/vbhagath"
+        },
+        {
+            "name": "Prathap Reddy"
+        }
+    ],
+    "title": "GDCR@ExpertTalks",
+    "url": "https://www.meetup.com/Experttalks-bengaluru/"
 }

--- a/_data/events_gdcr2018/Barcelona-Vueling.json
+++ b/_data/events_gdcr2018/Barcelona-Vueling.json
@@ -1,21 +1,29 @@
 {
-  "title": "GDCR18 in Barcelona",
-  "url": "https://www.eventbrite.es/e/global-day-of-code-retreat-barcelona-tickets-52519542365",
-  "moderators": [
-    "@polamat91",
-    "Daniel Labella"
-  ],
-  "sponsors": [
-    "@vueling"
-  ],
-  "location": {
-    "city": "El Prat de Llobregat",
-    "country": "Spain",
-    "coordinates": {
-      "latitude": 41.311288,
-      "longitude": 2.0712355
+    "location": {
+        "city": "El Prat de Llobregat",
+        "coordinates": {
+            "latitude": 41.311288,
+            "longitude": 2.0712355
+        },
+        "country": "Spain",
+        "timezone": "Europe/Madrid",
+        "utcOffset": 2
     },
-    "utcOffset": 2,
-    "timezone": "Europe/Madrid"
-  }
+    "moderators": [
+        {
+            "name": "Pol Amat Valls",
+            "url": "https://twitter.com/polamat91"
+        },
+        {
+            "name": "Daniel Labella"
+        }
+    ],
+    "sponsors": [
+        {
+            "name": "Vueling Airlines",
+            "url": "https://twitter.com/vueling"
+        }
+    ],
+    "title": "GDCR18 in Barcelona",
+    "url": "https://www.eventbrite.es/e/global-day-of-code-retreat-barcelona-tickets-52519542365"
 }

--- a/_data/events_gdcr2018/Barcelona.json
+++ b/_data/events_gdcr2018/Barcelona.json
@@ -1,17 +1,20 @@
 {
-  "title": "GDCR18 in Barcelona",
-  "url": "https://www.meetup.com/es-ES/BarcelonaJUG/events/256208230",
-  "moderators": [
-    "@icougil"
-  ],
-  "location": {
-    "city": "Barcelona",
-    "country": "Spain",
-    "coordinates": {
-      "latitude": 41.3948976,
-      "longitude": 2.0787279
+    "location": {
+        "city": "Barcelona",
+        "coordinates": {
+            "latitude": 41.3948976,
+            "longitude": 2.0787279
+        },
+        "country": "Spain",
+        "timezone": "Europe/Madrid",
+        "utcOffset": 2
     },
-    "utcOffset": 2,
-    "timezone": "Europe/Madrid"
-  }
+    "moderators": [
+        {
+            "name": "Nacho Cougil",
+            "url": "https://twitter.com/icougil"
+        }
+    ],
+    "title": "GDCR18 in Barcelona",
+    "url": "https://www.meetup.com/es-ES/BarcelonaJUG/events/256208230"
 }

--- a/_data/events_gdcr2018/Beijing-ThoughtWorks.json
+++ b/_data/events_gdcr2018/Beijing-ThoughtWorks.json
@@ -1,21 +1,32 @@
 {
-  "title": "GDCR 2018 in ThoughtWorks Beijing",
-  "url": "https://www.eventbrite.com.au/e/gdcr-2018-in-thoughtworks-beijing-tickets-51359756414",
-  "moderators": [
-    "@wubin28",
-    "Jin XU",
-    "Victory Yan WANG",
-    "Minmin QIU",
-    "Ying HE"
-  ],
-  "location": {
-    "city": "Beijing",
-    "country": "China",
-    "coordinates": {
-      "latitude": 39.9375183,
-      "longitude": 116.42804
+    "location": {
+        "city": "Beijing",
+        "coordinates": {
+            "latitude": 39.9375183,
+            "longitude": 116.42804
+        },
+        "country": "China",
+        "timezone": "Asia/Shanghai",
+        "utcOffset": 8
     },
-    "utcOffset": 8,
-    "timezone": "Asia/Shanghai"
-  }
+    "moderators": [
+        {
+            "name": "Ben WU",
+            "url": "https://twitter.com/wubin28"
+        },
+        {
+            "name": "Jin XU"
+        },
+        {
+            "name": "Victory Yan WANG"
+        },
+        {
+            "name": "Minmin QIU"
+        },
+        {
+            "name": "Ying HE"
+        }
+    ],
+    "title": "GDCR 2018 in ThoughtWorks Beijing",
+    "url": "https://www.eventbrite.com.au/e/gdcr-2018-in-thoughtworks-beijing-tickets-51359756414"
 }

--- a/_data/events_gdcr2018/Beijing.json
+++ b/_data/events_gdcr2018/Beijing.json
@@ -1,14 +1,19 @@
 {
-  "title": "Global Day of Code Retreat 2018 Beijing",
-  "url": "https://www.eventbrite.com/e/global-day-of-code-retreat-2018-beijing-tickets-51685731414",
-  "location": {
-    "city": "Beijing",
-    "country": "China",
-    "coordinates": {
-      "latitude": 40.012426,
-      "longitude": 116.490749
+    "location": {
+        "city": "Beijing",
+        "coordinates": {
+            "latitude": 40.012426,
+            "longitude": 116.490749
+        },
+        "country": "China",
+        "utcOffset": 8
     },
-    "utcOffset": 8
-  },
-  "moderators": ["@YugangB"]
+    "moderators": [
+        {
+            "name": "yugang bai",
+            "url": "https://twitter.com/YugangB"
+        }
+    ],
+    "title": "Global Day of Code Retreat 2018 Beijing",
+    "url": "https://www.eventbrite.com/e/global-day-of-code-retreat-2018-beijing-tickets-51685731414"
 }

--- a/_data/events_gdcr2018/BeloHorizonte.json
+++ b/_data/events_gdcr2018/BeloHorizonte.json
@@ -1,17 +1,20 @@
 {
-  "title": "GLOBAL DAY OF CODE RETREAT 2018 - BELO HORIZONTE",
-  "url": "https://www.sympla.com.br/global-day-of-code-retreat-2018---belo-horizonte__368004",
-  "moderators": [
-    "@guicorsino"
-  ],
-  "location": {
-    "city": "Belo Horizonte",
-    "country": "Brazil",
-    "coordinates": {
-      "latitude": -19.9173,
-      "longitude": -43.9346
+    "location": {
+        "city": "Belo Horizonte",
+        "coordinates": {
+            "latitude": -19.9173,
+            "longitude": -43.9346
+        },
+        "country": "Brazil",
+        "timezone": "America/Sao_Paulo",
+        "utcOffset": -3
     },
-    "utcOffset": -3,
-    "timezone": "America/Sao_Paulo"
-  }
+    "moderators": [
+        {
+            "name": "Guilherme Corsino",
+            "url": "https://twitter.com/guicorsino"
+        }
+    ],
+    "title": "GLOBAL DAY OF CODE RETREAT 2018 - BELO HORIZONTE",
+    "url": "https://www.sympla.com.br/global-day-of-code-retreat-2018---belo-horizonte__368004"
 }

--- a/_data/events_gdcr2018/Bend.json
+++ b/_data/events_gdcr2018/Bend.json
@@ -1,15 +1,20 @@
 {
-  "title": "GDCR18 Bend @ OSU Cascades",
-  "url": "https://www.eventbrite.com/e/bend-global-day-of-coderetreat-2018-tickets-49817889649",
-  "location": {
-    "utcOffset": -8,
-    "timezone": "America/Los_Angeles",
-    "city": "Bend",
-    "country": "United States of America",
-    "coordinates": {
-      "latitude": 44.0429237,
-      "longitude": -121.33567239
-    }
-  },
-  "moderators": ["@ybakos"]
+    "location": {
+        "city": "Bend",
+        "coordinates": {
+            "latitude": 44.0429237,
+            "longitude": -121.33567239
+        },
+        "country": "United States of America",
+        "timezone": "America/Los_Angeles",
+        "utcOffset": -8
+    },
+    "moderators": [
+        {
+            "name": "Yong Joseph Bakos",
+            "url": "https://twitter.com/ybakos"
+        }
+    ],
+    "title": "GDCR18 Bend @ OSU Cascades",
+    "url": "https://www.eventbrite.com/e/bend-global-day-of-coderetreat-2018-tickets-49817889649"
 }

--- a/_data/events_gdcr2018/Berlin.json
+++ b/_data/events_gdcr2018/Berlin.json
@@ -1,21 +1,30 @@
 {
-  "title": "GDCR Berlin 2018",
-  "url": "https://www.eventbrite.com/e/global-day-of-coderetreat-2018-softwerkskammer-berlin-tickets-51705259824",
-  "moderators": [
-    "@martinklose",
-    "@mrksdck"
-  ],
-  "sponsors": [
-    "@NI_News"
-  ],
-  "location": {
-    "city": "Berlin",
-    "country": "Germany",
-    "coordinates": {
-      "latitude": 52.4991677,
-      "longitude": 13.4455218
+    "location": {
+        "city": "Berlin",
+        "coordinates": {
+            "latitude": 52.4991677,
+            "longitude": 13.4455218
+        },
+        "country": "Germany",
+        "timezone": "Europe/Berlin",
+        "utcOffset": 2
     },
-    "utcOffset": 2,
-    "timezone": "Europe/Berlin"
-  }
+    "moderators": [
+        {
+            "name": "Martin Klose",
+            "url": "https://twitter.com/martinklose"
+        },
+        {
+            "name": "Markus Decke",
+            "url": "https://twitter.com/mrksdck"
+        }
+    ],
+    "sponsors": [
+        {
+            "name": "Native Instruments",
+            "url": "https://twitter.com/NI_News"
+        }
+    ],
+    "title": "GDCR Berlin 2018",
+    "url": "https://www.eventbrite.com/e/global-day-of-coderetreat-2018-softwerkskammer-berlin-tickets-51705259824"
 }

--- a/_data/events_gdcr2018/Bethesda.json
+++ b/_data/events_gdcr2018/Bethesda.json
@@ -1,21 +1,28 @@
 {
-  "title": "Global Day of Code Retreat - Bethesda",
-  "url": "https://www.eventbrite.com/e/global-day-of-code-retreat-bethesda-registration-51442748646",
-  "moderators": [
-    "Leah Belin",
-    "Steven Stewart"
-  ],
-  "sponsors": [
-    "@Homesnap"
-  ],
-  "location": {
-    "city": "Bethesda",
-    "country": "United States of America",
-    "coordinates": {
-      "latitude": 38.9815464,
-      "longitude": -77.0963168
+    "location": {
+        "city": "Bethesda",
+        "coordinates": {
+            "latitude": 38.9815464,
+            "longitude": -77.0963168
+        },
+        "country": "United States of America",
+        "timezone": "America/New_York",
+        "utcOffset": -4
     },
-    "utcOffset": -4,
-    "timezone": "America/New_York"
-  }
+    "moderators": [
+        {
+            "name": "Leah Belin"
+        },
+        {
+            "name": "Steven Stewart"
+        }
+    ],
+    "sponsors": [
+        {
+            "name": "Homesnap",
+            "url": "https://twitter.com/Homesnap"
+        }
+    ],
+    "title": "Global Day of Code Retreat - Bethesda",
+    "url": "https://www.eventbrite.com/e/global-day-of-code-retreat-bethesda-registration-51442748646"
 }

--- a/_data/events_gdcr2018/Bielefeld.json
+++ b/_data/events_gdcr2018/Bielefeld.json
@@ -1,20 +1,25 @@
 {
-  "title": "GDCR in Bielefeld",
-  "url": "https://www.softwerkskammer.org/activities/mob-gdcr-18",
-  "moderators": [
-    "Jaroslaw Klose"
-  ],
-  "sponsors": [
-    "@klosebrothers"
-  ],
-  "location": {
-    "city": "Bielefeld",
-    "country": "Germany",
-    "coordinates": {
-      "latitude": 52.0128017,
-      "longitude": 8.566494
+    "location": {
+        "city": "Bielefeld",
+        "coordinates": {
+            "latitude": 52.0128017,
+            "longitude": 8.566494
+        },
+        "country": "Germany",
+        "timezone": "Europe/Berlin",
+        "utcOffset": 1
     },
-    "utcOffset": 1,
-    "timezone": "Europe/Berlin"
-  }
+    "moderators": [
+        {
+            "name": "Jaroslaw Klose"
+        }
+    ],
+    "sponsors": [
+        {
+            "name": "klosebrothers",
+            "url": "https://twitter.com/klosebrothers"
+        }
+    ],
+    "title": "GDCR in Bielefeld",
+    "url": "https://www.softwerkskammer.org/activities/mob-gdcr-18"
 }

--- a/_data/events_gdcr2018/Bochum.json
+++ b/_data/events_gdcr2018/Bochum.json
@@ -1,22 +1,33 @@
 {
-  "title": "GDCR 2018 in Bochum at Softwerkskammer Ruhrgebiet",
-  "url": "https://www.meetup.com/de-DE/Softwerkskammer-Ruhrgebiet/events/252625478/",
-  "moderators": [
-    "@georgberky",
-    "@ThomasTraude",
-    "@kiview"
-  ],
-  "sponsors": [
-    "VMRay GmbH"
-  ],
-  "location": {
-    "city": "Bochum",
-    "country": "Germany",
-    "coordinates": {
-      "latitude": 51.4451438,
-      "longitude": 7.2565569
+    "location": {
+        "city": "Bochum",
+        "coordinates": {
+            "latitude": 51.4451438,
+            "longitude": 7.2565569
+        },
+        "country": "Germany",
+        "timezone": "Europe/Berlin",
+        "utcOffset": 1
     },
-    "utcOffset": 1,
-    "timezone": "Europe/Berlin"
-  }
+    "moderators": [
+        {
+            "name": "Georg Berky",
+            "url": "https://twitter.com/georgberky"
+        },
+        {
+            "name": "Thomas Traude",
+            "url": "https://twitter.com/ThomasTraude"
+        },
+        {
+            "name": "Kevin Wittek",
+            "url": "https://twitter.com/kiview"
+        }
+    ],
+    "sponsors": [
+        {
+            "name": "VMRay GmbH"
+        }
+    ],
+    "title": "GDCR 2018 in Bochum at Softwerkskammer Ruhrgebiet",
+    "url": "https://www.meetup.com/de-DE/Softwerkskammer-Ruhrgebiet/events/252625478/"
 }

--- a/_data/events_gdcr2018/Bordeaux.json
+++ b/_data/events_gdcr2018/Bordeaux.json
@@ -1,18 +1,24 @@
 {
-    "title": "GDCR18 Bordeaux",
-    "url": "http://meetu.ps/e/FZ0Yw/jnLhz/f",
-    "moderators": [
-      "@lilobase",
-      "@bodysplash"
-    ],
     "location": {
-      "city": "Bordeaux",
-      "country": "France",
-      "coordinates": {
-        "latitude": 44.8532256,
-        "longitude": -0.5920805
-      },
-      "utcOffset": 2,
-      "timezone": "Europe/Paris"
-    }
-  }
+        "city": "Bordeaux",
+        "coordinates": {
+            "latitude": 44.8532256,
+            "longitude": -0.5920805
+        },
+        "country": "France",
+        "timezone": "Europe/Paris",
+        "utcOffset": 2
+    },
+    "moderators": [
+        {
+            "name": "Arnaud LEMAIRE",
+            "url": "https://twitter.com/lilobase"
+        },
+        {
+            "name": "JB Dusseaut",
+            "url": "https://twitter.com/bodysplash"
+        }
+    ],
+    "title": "GDCR18 Bordeaux",
+    "url": "http://meetu.ps/e/FZ0Yw/jnLhz/f"
+}

--- a/_data/events_gdcr2018/Boston.json
+++ b/_data/events_gdcr2018/Boston.json
@@ -1,18 +1,23 @@
 {
-  "title": "Global Day of Coderetreat 2018 - Boston",
-  "url": "https://www.eventbrite.com/e/global-day-of-coderetreat-2018-boston-tickets-50447538947",
-  "moderators": [
-    "@mattc_baker",
-    "Ethan Strominger"
-  ],
-  "location": {
-    "city": "Boston",
-    "country": "United States of America",
-    "coordinates": {
-      "latitude": 42.3591165,
-      "longitude": -71.0586487
+    "location": {
+        "city": "Boston",
+        "coordinates": {
+            "latitude": 42.3591165,
+            "longitude": -71.0586487
+        },
+        "country": "United States of America",
+        "timezone": "America/New_York",
+        "utcOffset": -4
     },
-    "utcOffset": -4,
-    "timezone": "America/New_York"
-  }
+    "moderators": [
+        {
+            "name": "Matt Baker",
+            "url": "https://twitter.com/mattc_baker"
+        },
+        {
+            "name": "Ethan Strominger"
+        }
+    ],
+    "title": "Global Day of Coderetreat 2018 - Boston",
+    "url": "https://www.eventbrite.com/e/global-day-of-coderetreat-2018-boston-tickets-50447538947"
 }

--- a/_data/events_gdcr2018/Braunschweig.json
+++ b/_data/events_gdcr2018/Braunschweig.json
@@ -1,20 +1,26 @@
 {
-  "title": "HackCamp 6 Braunschweig",
-  "url": "https://hacktalk.de/#hackcamp",
-  "moderators": [
-    "@stevenschwenke"
-  ],
-  "sponsors": [
-    "@msgDAVID"
-  ],
-  "location": {
-    "city": "Braunschweig",
-    "country": "Germany",
-    "coordinates": {
-      "latitude": 52.2785341,
-      "longitude": 10.5245448
+    "location": {
+        "city": "Braunschweig",
+        "coordinates": {
+            "latitude": 52.2785341,
+            "longitude": 10.5245448
+        },
+        "country": "Germany",
+        "timezone": "Europe/Berlin",
+        "utcOffset": 2
     },
-    "utcOffset": 2,
-    "timezone": "Europe/Berlin"
-  }
+    "moderators": [
+        {
+            "name": "Steven Schwenke",
+            "url": "https://twitter.com/stevenschwenke"
+        }
+    ],
+    "sponsors": [
+        {
+            "name": "msg DAVID GmbH",
+            "url": "https://twitter.com/msgDAVID"
+        }
+    ],
+    "title": "HackCamp 6 Braunschweig",
+    "url": "https://hacktalk.de/#hackcamp"
 }

--- a/_data/events_gdcr2018/Brisbane.json
+++ b/_data/events_gdcr2018/Brisbane.json
@@ -1,22 +1,31 @@
 {
-  "title": "#gdcr Brisbane 2018",
-  "url": "https://www.eventbrite.com/e/global-day-of-coderetreat-gdcr-brisbane-2018-tickets-47256410195",
-  "moderators": [
-    "Nataliya",
-    "Joe",
-    "Lyall"
-  ],
-  "sponsors": [
-    "@thoughtworks"
-  ],
-  "location": {
-    "city": "Brisbane",
-    "country": "Australia",
-    "coordinates": {
-      "latitude": -27.4657034,
-      "longitude": 153.0273472
+    "location": {
+        "city": "Brisbane",
+        "coordinates": {
+            "latitude": -27.4657034,
+            "longitude": 153.0273472
+        },
+        "country": "Australia",
+        "timezone": "Australia/Brisbane",
+        "utcOffset": 10
     },
-    "utcOffset": 10,
-    "timezone": "Australia/Brisbane"
-  }
+    "moderators": [
+        {
+            "name": "Nataliya"
+        },
+        {
+            "name": "Joe"
+        },
+        {
+            "name": "Lyall"
+        }
+    ],
+    "sponsors": [
+        {
+            "name": "ThoughtWorks",
+            "url": "https://twitter.com/thoughtworks"
+        }
+    ],
+    "title": "#gdcr Brisbane 2018",
+    "url": "https://www.eventbrite.com/e/global-day-of-coderetreat-gdcr-brisbane-2018-tickets-47256410195"
 }

--- a/_data/events_gdcr2018/Brno-GDCR-2018.json
+++ b/_data/events_gdcr2018/Brno-GDCR-2018.json
@@ -1,18 +1,22 @@
 {
-  "title": "GDCR.Brno.2018 ",
-  "url": "https://www.solarwindsmeetup.com/event/gdcr-2018/",
-  "moderators": [
-    "Vladimir Kopso",
-    "Jakub Fojtl"
-  ],
-  "location": {
-    "city": "Brno",
-    "country": "Czech Republic",
-    "coordinates": {
-      "latitude": 49.1810045,
-      "longitude": 16.6036102
+    "location": {
+        "city": "Brno",
+        "coordinates": {
+            "latitude": 49.1810045,
+            "longitude": 16.6036102
+        },
+        "country": "Czech Republic",
+        "timezone": "Europe/Prague",
+        "utcOffset": 2
     },
-    "utcOffset": 2,
-    "timezone": "Europe/Prague"
-  }
+    "moderators": [
+        {
+            "name": "Vladimir Kopso"
+        },
+        {
+            "name": "Jakub Fojtl"
+        }
+    ],
+    "title": "GDCR.Brno.2018 ",
+    "url": "https://www.solarwindsmeetup.com/event/gdcr-2018/"
 }

--- a/_data/events_gdcr2018/Brooklyn.json
+++ b/_data/events_gdcr2018/Brooklyn.json
@@ -1,20 +1,26 @@
 {
-  "title": "GDCR18 in Brooklyn",
-  "url": "https://www.meetup.com/Community-Position-Dev/events/253609066/",
-  "moderators": [
-    "@horrorcheck"
-  ],
-  "location": {
-    "city": "Brooklyn, NY",
-    "country": "United States of America",
-    "coordinates": {
-      "latitude": 40.7041935,
-      "longitude": -73.9889684
+    "location": {
+        "city": "Brooklyn, NY",
+        "coordinates": {
+            "latitude": 40.7041935,
+            "longitude": -73.9889684
+        },
+        "country": "United States of America",
+        "timezone": "America/New_York",
+        "utcOffset": -4
     },
-    "utcOffset": -4,
-    "timezone": "America/New_York"
-  },
-  "sponsors": [
-    "@positiondev"
-  ]
+    "moderators": [
+        {
+            "name": "Libby Horacek",
+            "url": "https://twitter.com/horrorcheck"
+        }
+    ],
+    "sponsors": [
+        {
+            "name": "Position Dev",
+            "url": "https://twitter.com/positiondev"
+        }
+    ],
+    "title": "GDCR18 in Brooklyn",
+    "url": "https://www.meetup.com/Community-Position-Dev/events/253609066/"
 }

--- a/_data/events_gdcr2018/Bucharest-craftsmanship.json
+++ b/_data/events_gdcr2018/Bucharest-craftsmanship.json
@@ -1,19 +1,26 @@
 {
-  "title": "GDCR18 in Bucharest @ Craftsmanship",
-  "url": "http://meetu.ps/e/FZCzx/vNHvw/f",
-  "moderators": [
-    "@victorrentea",
-    "Bianca Falca",
-    "Marian Stanciu"
-  ],
-  "location": {
-    "city": "Bucharest",
-    "country": "Romania",
-    "coordinates": {
-      "latitude": 44.435642,
-      "longitude": 26.05408
+    "location": {
+        "city": "Bucharest",
+        "coordinates": {
+            "latitude": 44.435642,
+            "longitude": 26.05408
+        },
+        "country": "Romania",
+        "timezone": "Europe/Bucharest",
+        "utcOffset": 3
     },
-    "utcOffset": 3,
-    "timezone": "Europe/Bucharest"
-  }
+    "moderators": [
+        {
+            "name": "Victor Rentea",
+            "url": "https://twitter.com/victorrentea"
+        },
+        {
+            "name": "Bianca Falca"
+        },
+        {
+            "name": "Marian Stanciu"
+        }
+    ],
+    "title": "GDCR18 in Bucharest @ Craftsmanship",
+    "url": "http://meetu.ps/e/FZCzx/vNHvw/f"
 }

--- a/_data/events_gdcr2018/Bucharest.json
+++ b/_data/events_gdcr2018/Bucharest.json
@@ -1,20 +1,25 @@
 {
-  "title": "GDCR18 in Bucharest @ AgileWorks",
-  "url": "https://www.meetup.com/The-Bucharest-Agile-Software-Meetup-Group/events/255691980/",
-  "moderators": [
-    "@biancaleuca",
-    "@alinpandichi"
-  ],
-  "sponsors": [
-  ],
-  "location": {
-    "city": "Bucharest",
-    "country": "Romania",
-    "coordinates": {
-      "latitude": 44.4361414,
-      "longitude": 26.1027202
+    "location": {
+        "city": "Bucharest",
+        "coordinates": {
+            "latitude": 44.4361414,
+            "longitude": 26.1027202
+        },
+        "country": "Romania",
+        "timezone": "Europe/Bucharest",
+        "utcOffset": 2
     },
-    "utcOffset": 2,
-    "timezone": "Europe/Bucharest"
-  }
+    "moderators": [
+        {
+            "name": "Bianca L",
+            "url": "https://twitter.com/biancaleuca"
+        },
+        {
+            "name": "Alin Pandichi",
+            "url": "https://twitter.com/alinpandichi"
+        }
+    ],
+    "sponsors": [],
+    "title": "GDCR18 in Bucharest @ AgileWorks",
+    "url": "https://www.meetup.com/The-Bucharest-Agile-Software-Meetup-Group/events/255691980/"
 }

--- a/_data/events_gdcr2018/Calgary.json
+++ b/_data/events_gdcr2018/Calgary.json
@@ -1,18 +1,23 @@
 {
-  "title": "GDCR18 in Calgary Alberta",
-  "url": "https://www.meetup.com/Calgary-Agile-Methods-User-Group/events/",
-  "moderators": [
-    "@ttrungvo",
-    "Jacquenline"
-  ],
-  "location": {
-    "city": "Calgary",
-    "country": "Canada",
-    "coordinates": {
-      "latitude": 51.08451,
-      "longitude": -114.13042
+    "location": {
+        "city": "Calgary",
+        "coordinates": {
+            "latitude": 51.08451,
+            "longitude": -114.13042
+        },
+        "country": "Canada",
+        "timezone": "America/Edmonton",
+        "utcOffset": -6
     },
-    "utcOffset": -6,
-    "timezone": "America/Edmonton"
-  }
+    "moderators": [
+        {
+            "name": "Trung Vo",
+            "url": "https://twitter.com/ttrungvo"
+        },
+        {
+            "name": "Jacquenline"
+        }
+    ],
+    "title": "GDCR18 in Calgary Alberta",
+    "url": "https://www.meetup.com/Calgary-Agile-Methods-User-Group/events/"
 }

--- a/_data/events_gdcr2018/Cambridge.json
+++ b/_data/events_gdcr2018/Cambridge.json
@@ -1,22 +1,34 @@
 {
-  "title": "GDCR18 Cambridge, UK",
-  "url": "https://www.meetup.com/Cambridge-Software-Crafters/events/254650705/",
-  "moderators": [
-    "@ilkezilci",
-    "@AmelieCornelis",
-    "@alextercete"
-  ],
-  "sponsors": [
-    "@redgate"
-  ],
-  "location": {
-    "city": "Cambridge",
-    "country": "United Kingdom",
-    "coordinates": {
-      "latitude": 52.20806,
-      "longitude": 0.1225
+    "location": {
+        "city": "Cambridge",
+        "coordinates": {
+            "latitude": 52.20806,
+            "longitude": 0.1225
+        },
+        "country": "United Kingdom",
+        "timezone": "Europe/London",
+        "utcOffset": 1
     },
-    "utcOffset": 1,
-    "timezone": "Europe/London"
-  }
+    "moderators": [
+        {
+            "name": "Ilke Zilci",
+            "url": "https://twitter.com/ilkezilci"
+        },
+        {
+            "name": "Am\u00e9lie Corn\u00e9lis",
+            "url": "https://twitter.com/AmelieCornelis"
+        },
+        {
+            "name": "Alex Tercete",
+            "url": "https://twitter.com/alextercete"
+        }
+    ],
+    "sponsors": [
+        {
+            "name": "Redgate",
+            "url": "https://twitter.com/redgate"
+        }
+    ],
+    "title": "GDCR18 Cambridge, UK",
+    "url": "https://www.meetup.com/Cambridge-Software-Crafters/events/254650705/"
 }

--- a/_data/events_gdcr2018/Chicago.json
+++ b/_data/events_gdcr2018/Chicago.json
@@ -1,21 +1,30 @@
 {
-  "title": "GDCR18 in Chicago",
-  "url": "https://www.meetup.com/8th-light-university/events/254951280/",
-  "moderators": [
-    "@NicoleCarpUSA",
-    "@EMeyer8thLight"
-  ],
-  "sponsors": [
-    "@8thLightInc"
-  ],
-  "location": {
-    "city": "Chicago",
-    "country": "United States of America",
-    "coordinates": {
-      "latitude": 41.8830478,
-      "longitude": -87.6290087
+    "location": {
+        "city": "Chicago",
+        "coordinates": {
+            "latitude": 41.8830478,
+            "longitude": -87.6290087
+        },
+        "country": "United States of America",
+        "timezone": "America/Chicago",
+        "utcOffset": -5
     },
-    "utcOffset": -5,
-    "timezone": "America/Chicago"
-  }
+    "moderators": [
+        {
+            "name": "Nicole",
+            "url": "https://twitter.com/NicoleCarpUSA"
+        },
+        {
+            "name": "Eric Meyer",
+            "url": "https://twitter.com/EMeyer8thLight"
+        }
+    ],
+    "sponsors": [
+        {
+            "name": "8th Light",
+            "url": "https://twitter.com/8thLightInc"
+        }
+    ],
+    "title": "GDCR18 in Chicago",
+    "url": "https://www.meetup.com/8th-light-university/events/254951280/"
 }

--- a/_data/events_gdcr2018/Cluj.json
+++ b/_data/events_gdcr2018/Cluj.json
@@ -1,19 +1,28 @@
 {
-  "title": "GDCR18 in Cluj",
-  "url": "http://www.rabs.ro/events?ee=22",
-  "moderators": [
-    "@horea_hopartean",
-    "@florincoros",
-    "@sergiudamian"
-  ],
-  "location": {
-    "city": "Cluj-Napoca",
-    "country": "Romania",
-    "coordinates": {
-      "latitude": 46.773318,
-      "longitude": 23.589607
+    "location": {
+        "city": "Cluj-Napoca",
+        "coordinates": {
+            "latitude": 46.773318,
+            "longitude": 23.589607
+        },
+        "country": "Romania",
+        "timezone": "Europe/Bucharest",
+        "utcOffset": 3
     },
-    "utcOffset": 3,
-    "timezone": "Europe/Bucharest"
-  }
+    "moderators": [
+        {
+            "name": "Horea Hopartean",
+            "url": "https://twitter.com/horea_hopartean"
+        },
+        {
+            "name": "Florin Coros",
+            "url": "https://twitter.com/florincoros"
+        },
+        {
+            "name": "Sergiu Damian",
+            "url": "https://twitter.com/sergiudamian"
+        }
+    ],
+    "title": "GDCR18 in Cluj",
+    "url": "http://www.rabs.ro/events?ee=22"
 }

--- a/_data/events_gdcr2018/Cologne.json
+++ b/_data/events_gdcr2018/Cologne.json
@@ -1,22 +1,33 @@
 {
-  "title": "GDCR 2018 Softwerkskammer Köln @lisegmbh",
-  "url": "https://www.meetup.com/de-DE/Softwerkskammer-Koln/events/255294577/",
-  "moderators": [
-    "@skorzinetzki",
-    "@bikratz",
-    "Martin Dieblich"
-  ],
-  "sponsors": [
-    "@lisegmbh"
-  ],
-  "location": {
-    "city": "Cologne",
-    "country": "Germany",
-    "coordinates": {
-      "latitude": 50.9847388,
-      "longitude": 6.8879454
+    "location": {
+        "city": "Cologne",
+        "coordinates": {
+            "latitude": 50.9847388,
+            "longitude": 6.8879454
+        },
+        "country": "Germany",
+        "timezone": "Europe/Berlin",
+        "utcOffset": 2
     },
-    "utcOffset": 2,
-    "timezone": "Europe/Berlin"
-  }
+    "moderators": [
+        {
+            "name": "Steve Korzinetzki",
+            "url": "https://twitter.com/skorzinetzki"
+        },
+        {
+            "name": "Birgit Kratz",
+            "url": "https://twitter.com/bikratz"
+        },
+        {
+            "name": "Martin Dieblich"
+        }
+    ],
+    "sponsors": [
+        {
+            "name": "lise GmbH",
+            "url": "https://twitter.com/lisegmbh"
+        }
+    ],
+    "title": "GDCR 2018 Softwerkskammer K\u00f6ln @lisegmbh",
+    "url": "https://www.meetup.com/de-DE/Softwerkskammer-Koln/events/255294577/"
 }

--- a/_data/events_gdcr2018/ColumbusOH.json
+++ b/_data/events_gdcr2018/ColumbusOH.json
@@ -1,22 +1,32 @@
 {
-  "title": "GDCR18 in Columbus OH",
-  "url": "https://www.meetup.com/techlifecolumbus/events/253634066/",
-  "moderators": [
-    "@jlacar",
-    "Jim McClure",
-    "Kevin Smith"
-  ],
-  "sponsors": [
-    "@PillarTech"
-  ],
-  "location": {
-    "city": "Columbus, OH",
-    "country": "United States of America",
-    "coordinates": {
-      "latitude": 39.9748172,
-      "longitude": -82.99992
+    "location": {
+        "city": "Columbus, OH",
+        "coordinates": {
+            "latitude": 39.9748172,
+            "longitude": -82.99992
+        },
+        "country": "United States of America",
+        "timezone": "America/Detroit",
+        "utcOffset": -4
     },
-    "utcOffset": -4,
-    "timezone": "America/Detroit"
-  }
+    "moderators": [
+        {
+            "name": "Junilu Lacar",
+            "url": "https://twitter.com/jlacar"
+        },
+        {
+            "name": "Jim McClure"
+        },
+        {
+            "name": "Kevin Smith"
+        }
+    ],
+    "sponsors": [
+        {
+            "name": "Pillar Technology",
+            "url": "https://twitter.com/PillarTech"
+        }
+    ],
+    "title": "GDCR18 in Columbus OH",
+    "url": "https://www.meetup.com/techlifecolumbus/events/253634066/"
 }

--- a/_data/events_gdcr2018/Dearborn.json
+++ b/_data/events_gdcr2018/Dearborn.json
@@ -1,17 +1,19 @@
 {
-  "title": "GDCR in Dearborn",
-  "url": "https://www.eventbrite.com/e/global-day-of-code-retreat-henry-ford-college-tickets-50880312384?aff=ebdssbdestsearch",
-  "moderators": [
-    "Kim Moscardelli"
-  ],
-  "location": {
-    "city": "Dearborn",
-    "country": "United States of America",
-    "coordinates": {
-      "latitude": 42.3241,
-      "longitude": 83.2368
+    "location": {
+        "city": "Dearborn",
+        "coordinates": {
+            "latitude": 42.3241,
+            "longitude": 83.2368
+        },
+        "country": "United States of America",
+        "timezone": "America/Detroit",
+        "utcOffset": -4
     },
-    "utcOffset": -4,
-    "timezone": "America/Detroit"
-  }
+    "moderators": [
+        {
+            "name": "Kim Moscardelli"
+        }
+    ],
+    "title": "GDCR in Dearborn",
+    "url": "https://www.eventbrite.com/e/global-day-of-code-retreat-henry-ford-college-tickets-50880312384?aff=ebdssbdestsearch"
 }

--- a/_data/events_gdcr2018/DesMoines.json
+++ b/_data/events_gdcr2018/DesMoines.json
@@ -1,21 +1,32 @@
 {
-  "title": "GDCR18 Des Moines @ The Forge by Pillar Technology",
-  "url": "https://goo.gl/forms/8BYGJRe3whgGT1dz1",
-  "moderators": [
-    "@torisstoryy",
-    "Anthony Clifton",
-    "Michael Patterson",
-    "Koll Johnson",
-    "Liz Wells"
-  ],
-  "location": {
-    "city": "Des Moines",
-    "country": "United States of America",
-    "coordinates": {
-      "latitude": 41.5667771,
-      "longitude": -93.6765558
+    "location": {
+        "city": "Des Moines",
+        "coordinates": {
+            "latitude": 41.5667771,
+            "longitude": -93.6765558
+        },
+        "country": "United States of America",
+        "timezone": "America/Chicago",
+        "utcOffset": -5
     },
-    "utcOffset": -5,
-    "timezone": "America/Chicago"
-  }
+    "moderators": [
+        {
+            "name": "Tori",
+            "url": "https://twitter.com/torisstoryy"
+        },
+        {
+            "name": "Anthony Clifton"
+        },
+        {
+            "name": "Michael Patterson"
+        },
+        {
+            "name": "Koll Johnson"
+        },
+        {
+            "name": "Liz Wells"
+        }
+    ],
+    "title": "GDCR18 Des Moines @ The Forge by Pillar Technology",
+    "url": "https://goo.gl/forms/8BYGJRe3whgGT1dz1"
 }

--- a/_data/events_gdcr2018/Dublin.json
+++ b/_data/events_gdcr2018/Dublin.json
@@ -1,20 +1,32 @@
 {
-    "title": "GDCR18 in Dublin",
-    "url": "https://www.meetup.com/Dublin-Software-Crafters/events/255174388/",
-    "moderators": [
-      "@pclavijo",
-      "@gabrielmoral",
-      "@DublinSwCraft",
-      "@CorkSwCraft"
-    ],
     "location": {
-      "city": "Dublin",
-      "country": "Ireland",
-      "coordinates": {
-        "latitude": 53.3244431,
-        "longitude": -6.3857867
-      },
-      "utcOffset": 1,
-      "timezone": "Europe/Dublin"
-    }
-  }
+        "city": "Dublin",
+        "coordinates": {
+            "latitude": 53.3244431,
+            "longitude": -6.3857867
+        },
+        "country": "Ireland",
+        "timezone": "Europe/Dublin",
+        "utcOffset": 1
+    },
+    "moderators": [
+        {
+            "name": "Paulo Clavijo",
+            "url": "https://twitter.com/pclavijo"
+        },
+        {
+            "name": "Gabriel Moral",
+            "url": "https://twitter.com/gabrielmoral"
+        },
+        {
+            "name": "Dublin Software Crafters",
+            "url": "https://twitter.com/DublinSwCraft"
+        },
+        {
+            "name": "Cork Software Craft",
+            "url": "https://twitter.com/CorkSwCraft"
+        }
+    ],
+    "title": "GDCR18 in Dublin",
+    "url": "https://www.meetup.com/Dublin-Software-Crafters/events/255174388/"
+}

--- a/_data/events_gdcr2018/Duesseldorf.json
+++ b/_data/events_gdcr2018/Duesseldorf.json
@@ -1,21 +1,28 @@
 {
-  "title": "GDCR18 Softwerkskammer Düsseldorf",
-  "url": "https://www.meetup.com/de-DE/Softwerkskammer-Dusseldorf/events/254684323",
-  "moderators": [
-    "@zordan_f",
-    "Ulrich Freyer-Hirtz"
-  ],
-  "sponsors": [
-    "https://corporate.vorwerk.de/home/"
-  ],
-  "location": {
-    "city": "Düsseldorf",
-    "country": "Germany",
-    "coordinates": {
-      "latitude": 51.27593,
-      "longitude": 6.770758
+    "location": {
+        "city": "D\u00fcsseldorf",
+        "coordinates": {
+            "latitude": 51.27593,
+            "longitude": 6.770758
+        },
+        "country": "Germany",
+        "timezone": "Europe/Berlin",
+        "utcOffset": 1
     },
-    "utcOffset": 1,
-    "timezone": "Europe/Berlin"
-  }
+    "moderators": [
+        {
+            "name": "Tim Riemer",
+            "url": "https://twitter.com/zordan_f"
+        },
+        {
+            "name": "Ulrich Freyer-Hirtz"
+        }
+    ],
+    "sponsors": [
+        {
+            "name": "https://corporate.vorwerk.de/home/"
+        }
+    ],
+    "title": "GDCR18 Softwerkskammer D\u00fcsseldorf",
+    "url": "https://www.meetup.com/de-DE/Softwerkskammer-Dusseldorf/events/254684323"
 }

--- a/_data/events_gdcr2018/Essen.json
+++ b/_data/events_gdcr2018/Essen.json
@@ -1,18 +1,22 @@
 {
-    "title": "Global Day of Coderetreat 2018 Essen",
-    "url": "https://www.meetup.com/de-DE/JUG-Essen/events/254203335/",
-    "moderators": [
-      "Dr. Hannes Olivier",
-      "Sascha Wiedenfeld"
-    ],
     "location": {
-      "city": "Essen",
-      "country": "Germany",
-      "coordinates": {
-        "latitude": 51.4556366,
-        "longitude": 6.9976476
-      },
-      "utcOffset": 1,
-      "timezone": "Europe/Berlin"
-    }
-  }
+        "city": "Essen",
+        "coordinates": {
+            "latitude": 51.4556366,
+            "longitude": 6.9976476
+        },
+        "country": "Germany",
+        "timezone": "Europe/Berlin",
+        "utcOffset": 1
+    },
+    "moderators": [
+        {
+            "name": "Dr. Hannes Olivier"
+        },
+        {
+            "name": "Sascha Wiedenfeld"
+        }
+    ],
+    "title": "Global Day of Coderetreat 2018 Essen",
+    "url": "https://www.meetup.com/de-DE/JUG-Essen/events/254203335/"
+}

--- a/_data/events_gdcr2018/Firenze.json
+++ b/_data/events_gdcr2018/Firenze.json
@@ -1,18 +1,24 @@
 {
-    "title": "GDCR18 Firenze",
-    "url": "https://www.meetup.com/it-IT/ALT-AGILE-LEAN-TUSCANY/events/255488183/",
-    "moderators": [
-      "@andreavallotti",
-      "@marcocastellani"
-    ],
     "location": {
-      "city": "Florence",
-      "country": "Italy",
-      "coordinates": {
-        "latitude": 43.7764393,
-        "longitude": 11.2496527
-      },
-      "utcOffset": 2,
-      "timezone": "Europe/Rome"
-    }
-  }
+        "city": "Florence",
+        "coordinates": {
+            "latitude": 43.7764393,
+            "longitude": 11.2496527
+        },
+        "country": "Italy",
+        "timezone": "Europe/Rome",
+        "utcOffset": 2
+    },
+    "moderators": [
+        {
+            "name": "Andrea Vallotti",
+            "url": "https://twitter.com/andreavallotti"
+        },
+        {
+            "name": "Marco Castellani",
+            "url": "https://twitter.com/marcocastellani"
+        }
+    ],
+    "title": "GDCR18 Firenze",
+    "url": "https://www.meetup.com/it-IT/ALT-AGILE-LEAN-TUSCANY/events/255488183/"
+}

--- a/_data/events_gdcr2018/Frankfurt.json
+++ b/_data/events_gdcr2018/Frankfurt.json
@@ -1,21 +1,30 @@
 {
-  "title": "GDCR 2018 Frankfurt",
-  "url": "https://global-day-of-coderetreat-2018-frankfurt.eventbrite.de",
-  "moderators": [
-    "@svenlange",
-    "@CodeRetreatFfm"
-  ],
-  "sponsors": [
-    "@_dwpbank"
-  ],
-  "location": {
-    "city": "Frankfurt",
-    "country": "Germany",
-    "coordinates": {
-      "latitude": 50.122675,
-      "longitude": 8.650012
+    "location": {
+        "city": "Frankfurt",
+        "coordinates": {
+            "latitude": 50.122675,
+            "longitude": 8.650012
+        },
+        "country": "Germany",
+        "timezone": "Europe/Berlin",
+        "utcOffset": 1
     },
-    "utcOffset": 1,
-    "timezone": "Europe/Berlin"
-  }
+    "moderators": [
+        {
+            "name": "Sven Lange",
+            "url": "https://twitter.com/svenlange"
+        },
+        {
+            "name": "CodeRetreat Rhein-Ma",
+            "url": "https://twitter.com/CodeRetreatFfm"
+        }
+    ],
+    "sponsors": [
+        {
+            "name": "Deutsche WertpapierService Bank AG",
+            "url": "https://twitter.com/_dwpbank"
+        }
+    ],
+    "title": "GDCR 2018 Frankfurt",
+    "url": "https://global-day-of-coderetreat-2018-frankfurt.eventbrite.de"
 }

--- a/_data/events_gdcr2018/Fulda.json
+++ b/_data/events_gdcr2018/Fulda.json
@@ -1,21 +1,30 @@
 {
-  "title": "GDCR18 Hochschule Fulda",
-  "url": "https://doodle.com/poll/zvs55i69rf3irbrd",
-  "moderators": [
-    "Thomas.Papendieck@OPITZ-CONSULTING.com",
-    "Jörg Kreiker <joerg.kreiker@informatik.hs-fulda.de>"
-  ],
-  "sponsors": [
-    "@OC_WIRE"
-  ],
-  "location": {
-    "city": "Fulda",
-    "country": "Germany",
-    "coordinates": {
-      "latitude": 50.56518,
-      "longitude": 9.68448
+    "location": {
+        "city": "Fulda",
+        "coordinates": {
+            "latitude": 50.56518,
+            "longitude": 9.68448
+        },
+        "country": "Germany",
+        "timezone": "Europe/Berlin",
+        "utcOffset": 1
     },
-    "utcOffset": 1,
-    "timezone": "Europe/Berlin"
-  }
+    "moderators": [
+        {
+            "name": "Thomas Papendieck",
+            "url": "mailto:Thomas.Papendieck@OPITZ-CONSULTING.com"
+        },
+        {
+            "name": "J\u00f6rg Kreiker",
+            "url": "mailto:joerg.kreiker@informatik.hs-fulda.de"
+        }
+    ],
+    "sponsors": [
+        {
+            "name": "OPITZ CONSULTING",
+            "url": "https://twitter.com/OC_WIRE"
+        }
+    ],
+    "title": "GDCR18 Hochschule Fulda",
+    "url": "https://doodle.com/poll/zvs55i69rf3irbrd"
 }

--- a/_data/events_gdcr2018/Gdansk.json
+++ b/_data/events_gdcr2018/Gdansk.json
@@ -1,21 +1,28 @@
 {
-  "title": "Global Day of Coderetreat - Gdansk 2018",
-  "url": "https://softwaretalks.pl/wydarzenia/global-day-coderetreat-3/",
-  "moderators": [
-    "Krzysztof Kakol",
-    "Iga Zacher-Czempa"
-  ],
-  "sponsors": [
-    "@pgssoftware"
-  ],
-  "location": {
-    "city": "Gdansk",
-    "country": "Poland",
-    "coordinates": {
-      "latitude": 54.3605361,
-      "longitude": 18.6450142
+    "location": {
+        "city": "Gdansk",
+        "coordinates": {
+            "latitude": 54.3605361,
+            "longitude": 18.6450142
+        },
+        "country": "Poland",
+        "timezone": "Europe/Warsaw",
+        "utcOffset": 2
     },
-    "utcOffset": 2,
-    "timezone": "Europe/Warsaw"
-  }
+    "moderators": [
+        {
+            "name": "Krzysztof Kakol"
+        },
+        {
+            "name": "Iga Zacher-Czempa"
+        }
+    ],
+    "sponsors": [
+        {
+            "name": "PGS Software",
+            "url": "https://twitter.com/pgssoftware"
+        }
+    ],
+    "title": "Global Day of Coderetreat - Gdansk 2018",
+    "url": "https://softwaretalks.pl/wydarzenia/global-day-coderetreat-3/"
 }

--- a/_data/events_gdcr2018/Glasgow.json
+++ b/_data/events_gdcr2018/Glasgow.json
@@ -1,17 +1,20 @@
 {
-  "title": "GDCR18 in Glasgow",
-  "url": "https://gdcr18-gla.eventbrite.co.uk",
-  "moderators": [
-    "@_kbremner"
-  ],
-  "location": {
-    "city": "Glasgow",
-    "country": "United Kingdom",
-    "coordinates": {
-      "latitude": 55.870075,
-      "longitude": -4.251323
+    "location": {
+        "city": "Glasgow",
+        "coordinates": {
+            "latitude": 55.870075,
+            "longitude": -4.251323
+        },
+        "country": "United Kingdom",
+        "timezone": "Europe/London",
+        "utcOffset": 1
     },
-    "utcOffset": 1,
-    "timezone": "Europe/London"
-  }
+    "moderators": [
+        {
+            "name": "Kyle Bremner",
+            "url": "https://twitter.com/_kbremner"
+        }
+    ],
+    "title": "GDCR18 in Glasgow",
+    "url": "https://gdcr18-gla.eventbrite.co.uk"
 }

--- a/_data/events_gdcr2018/Hannover.json
+++ b/_data/events_gdcr2018/Hannover.json
@@ -1,17 +1,20 @@
 {
-  "title": "GDCR 2018 in Hannover",
-  "url": "https://www.meetup.com/Zuehlke-Hannover/events/255741486/",
-  "moderators": [
-    "@nilswz"
-  ],
-  "location": {
-    "city": "Hannover",
-    "country": "Germany",
-    "coordinates":{
-    "latitude":52.40769446411487,
-    "longitude":9.802991151809692
+    "location": {
+        "city": "Hannover",
+        "coordinates": {
+            "latitude": 52.40769446411487,
+            "longitude": 9.802991151809692
+        },
+        "country": "Germany",
+        "timezone": "Europe/Berlin",
+        "utcOffset": 2
     },
-    "utcOffset": 2,
-    "timezone": "Europe/Berlin"
-  }
+    "moderators": [
+        {
+            "name": "nils weinzierl",
+            "url": "https://twitter.com/nilswz"
+        }
+    ],
+    "title": "GDCR 2018 in Hannover",
+    "url": "https://www.meetup.com/Zuehlke-Hannover/events/255741486/"
 }

--- a/_data/events_gdcr2018/Hyderabad-India-CDKGlobal.json
+++ b/_data/events_gdcr2018/Hyderabad-India-CDKGlobal.json
@@ -1,18 +1,24 @@
 {
-  "title": "Coderetreat @ CDK Global (India) Pvt. Ltd.",
-  "url": "https://sites.google.com/view/cdkhyderabadevents",
-  "moderators": [
-    "@gsunder",
-    "@shaileshaag"
-  ],
-  "location": {
-    "city": "Hyderabad",
-    "country": "India",
-    "coordinates": {
-      "latitude": 17.4379805,
-      "longitude": 78.3825695
+    "location": {
+        "city": "Hyderabad",
+        "coordinates": {
+            "latitude": 17.4379805,
+            "longitude": 78.3825695
+        },
+        "country": "India",
+        "timezone": "Asia/Kolkata",
+        "utcOffset": 5.5
     },
-    "utcOffset": 5.5,
-    "timezone": "Asia/Kolkata"
-  }
+    "moderators": [
+        {
+            "name": "gsunder",
+            "url": "https://twitter.com/gsunder"
+        },
+        {
+            "name": "Shailesh Agarwal",
+            "url": "https://twitter.com/shaileshaag"
+        }
+    ],
+    "title": "Coderetreat @ CDK Global (India) Pvt. Ltd.",
+    "url": "https://sites.google.com/view/cdkhyderabadevents"
 }

--- a/_data/events_gdcr2018/Hyderabad-JugHyd.json
+++ b/_data/events_gdcr2018/Hyderabad-JugHyd.json
@@ -1,17 +1,20 @@
 {
-  "title": "GDCR18 @ JugHyd",
-  "url": "https://www.meetup.com/jughyderabad/events/bvsjppyxpbwb/",
-  "moderators": [
-    "@surajeet_sen"
-  ],
-  "location": {
-    "city": "Hyderabad",
-    "country": "India",
-    "coordinates": {
-      "latitude": 17.38714,
-      "longitude": 78.491684
+    "location": {
+        "city": "Hyderabad",
+        "coordinates": {
+            "latitude": 17.38714,
+            "longitude": 78.491684
+        },
+        "country": "India",
+        "timezone": "Asia/Kolkata",
+        "utcOffset": 5.5
     },
-    "utcOffset": 5.5,
-    "timezone": "Asia/Kolkata"
-  }
+    "moderators": [
+        {
+            "name": "Surajeet Sen",
+            "url": "https://twitter.com/surajeet_sen"
+        }
+    ],
+    "title": "GDCR18 @ JugHyd",
+    "url": "https://www.meetup.com/jughyderabad/events/bvsjppyxpbwb/"
 }

--- a/_data/events_gdcr2018/Istanbul-GittiGidiyor.json
+++ b/_data/events_gdcr2018/Istanbul-GittiGidiyor.json
@@ -1,23 +1,38 @@
 {
-  "title": "GDCR 2018 @ GittiGidiyor",
-  "url": "https://goo.gl/forms/k3jgGzIHQCrUOdFS2",
-  "moderators": [
-    "@h_yardimci",
-    "@cmyeniceri",
-    "@sekersizcayy",
-    "@veysiertekin"
-  ],
-  "sponsors": [
-    "@GittiGidiyor"
-  ],
-  "location": {
-    "city": "Istanbul",
-    "country": "Turkey",
-    "coordinates": {
-      "latitude": 40.9902205,
-      "longitude": 29.1025393
+    "location": {
+        "city": "Istanbul",
+        "coordinates": {
+            "latitude": 40.9902205,
+            "longitude": 29.1025393
+        },
+        "country": "Turkey",
+        "timezone": "Europe/Istanbul",
+        "utcOffset": 3
     },
-    "utcOffset": 3,
-    "timezone": "Europe/Istanbul"
-  }
+    "moderators": [
+        {
+            "name": "harun.",
+            "url": "https://twitter.com/h_yardimci"
+        },
+        {
+            "name": "Cem Yeni\u00e7eri",
+            "url": "https://twitter.com/cmyeniceri"
+        },
+        {
+            "name": "R",
+            "url": "https://twitter.com/sekersizcayy"
+        },
+        {
+            "name": "Veysi Ertekin",
+            "url": "https://twitter.com/veysiertekin"
+        }
+    ],
+    "sponsors": [
+        {
+            "name": "GittiGidiyor",
+            "url": "https://twitter.com/GittiGidiyor"
+        }
+    ],
+    "title": "GDCR 2018 @ GittiGidiyor",
+    "url": "https://goo.gl/forms/k3jgGzIHQCrUOdFS2"
 }

--- a/_data/events_gdcr2018/Istanbul-SCTurkey.json
+++ b/_data/events_gdcr2018/Istanbul-SCTurkey.json
@@ -1,18 +1,24 @@
 {
-  "title": "Global Day of Coderetreat 2018 Festival",
-  "url": "https://www.meetup.com/Software-Craftsmanship-Turkey/events/256000993/",
-  "moderators": [
-    "@scturkey",
-    "@lemiorhan"
-  ],
-  "location": {
-    "city": "Istanbul",
-    "country": "Turkey",
-    "coordinates": {
-      "latitude": 41.0283822,
-      "longitude": 29.1144979
+    "location": {
+        "city": "Istanbul",
+        "coordinates": {
+            "latitude": 41.0283822,
+            "longitude": 29.1144979
+        },
+        "country": "Turkey",
+        "timezone": "Europe/Istanbul",
+        "utcOffset": 3
     },
-    "utcOffset": 3,
-    "timezone": "Europe/Istanbul"
-  }
+    "moderators": [
+        {
+            "name": "SCTurkey",
+            "url": "https://twitter.com/scturkey"
+        },
+        {
+            "name": "Lemi Orhan Ergin",
+            "url": "https://twitter.com/lemiorhan"
+        }
+    ],
+    "title": "Global Day of Coderetreat 2018 Festival",
+    "url": "https://www.meetup.com/Software-Craftsmanship-Turkey/events/256000993/"
 }

--- a/_data/events_gdcr2018/Istanbul.json
+++ b/_data/events_gdcr2018/Istanbul.json
@@ -1,21 +1,36 @@
 {
-  "title": "GDCR18 @ JUG, Istanbul",
-  "url": "https://www.meetup.com/tr-TR/Istanbul-Java-User-Group/events/255419519/",
-  "moderators": [
-    "@jug_istanbul",
-    "@tdiler",
-    "@altugaltintas",
-    "@ajitatif",
-    "@taylankurt_0101"
-  ],
-  "location": {
-    "city": "Istanbul",
-    "country": "Turkey",
-    "coordinates": {
-      "latitude": 41.107864,
-      "longitude": 29.014023
+    "location": {
+        "city": "Istanbul",
+        "coordinates": {
+            "latitude": 41.107864,
+            "longitude": 29.014023
+        },
+        "country": "Turkey",
+        "timezone": "Europe/Istanbul",
+        "utcOffset": 3
     },
-    "utcOffset": 3,
-    "timezone": "Europe/Istanbul"
-  }
+    "moderators": [
+        {
+            "name": "JUG ISTANBUL",
+            "url": "https://twitter.com/jug_istanbul"
+        },
+        {
+            "name": "Taner Diler",
+            "url": "https://twitter.com/tdiler"
+        },
+        {
+            "name": "Altu\u011f B. Alt\u0131nta\u015f",
+            "url": "https://twitter.com/altugaltintas"
+        },
+        {
+            "name": "G\u00f6kalp G\u00fcrb\u00fczer",
+            "url": "https://twitter.com/ajitatif"
+        },
+        {
+            "name": "@taylankurt_0101",
+            "url": "https://twitter.com/taylankurt_0101"
+        }
+    ],
+    "title": "GDCR18 @ JUG, Istanbul",
+    "url": "https://www.meetup.com/tr-TR/Istanbul-Java-User-Group/events/255419519/"
 }

--- a/_data/events_gdcr2018/Johannesburg-Jemstep.json
+++ b/_data/events_gdcr2018/Johannesburg-Jemstep.json
@@ -1,16 +1,23 @@
 {
-  "title": "Global Day of Functional Coderetreat - Johannesburg",
-  "url": "http://meetu.ps/e/FY230/6G9jW/f",
-  "moderators": [
-    "@jancowol", "@kevintrethewey"
-  ],
-  "location": {
-    "city": "Johannesburg",
-    "country": "South Africa",
-    "coordinates": {
-      "latitude": -26.0594097,
-      "longitude": 27.9875978
+    "location": {
+        "city": "Johannesburg",
+        "coordinates": {
+            "latitude": -26.0594097,
+            "longitude": 27.9875978
+        },
+        "country": "South Africa",
+        "utcOffset": 2
     },
-    "utcOffset": 2
-  }
+    "moderators": [
+        {
+            "name": "Janco Wolmarans",
+            "url": "https://twitter.com/jancowol"
+        },
+        {
+            "name": "Kevin Trethewey",
+            "url": "https://twitter.com/kevintrethewey"
+        }
+    ],
+    "title": "Global Day of Functional Coderetreat - Johannesburg",
+    "url": "http://meetu.ps/e/FY230/6G9jW/f"
 }

--- a/_data/events_gdcr2018/Kaiserslautern.json
+++ b/_data/events_gdcr2018/Kaiserslautern.json
@@ -1,24 +1,42 @@
 {
-  "title": "GDCR 2018 Kaiserslautern",
-  "url": "http://softwerkskammer-rlp.de/events/4/global-day-of-coderetreat/",
-  "moderators": [
-    "@Softwerkskamme2",
-    "@JUG_KL",
-    "@chaos_inkl"
-  ],
-  "sponsors": [
-    "@Avid",
-    "@TOPdesk_DE",
-    "@EmpolisSoftware"
-  ],
-  "location": {
-    "city": "Kaiserslautern",
-    "country": "Germany",
-    "coordinates": {
-      "latitude": 49.4405018,
-      "longitude": 7.7603026
+    "location": {
+        "city": "Kaiserslautern",
+        "coordinates": {
+            "latitude": 49.4405018,
+            "longitude": 7.7603026
+        },
+        "country": "Germany",
+        "timezone": "Europe/Berlin",
+        "utcOffset": 1
     },
-    "utcOffset": 1,
-    "timezone": "Europe/Berlin"
-  }
+    "moderators": [
+        {
+            "name": "Softwerkskammer Rheinland-Pfalz",
+            "url": "https://twitter.com/Softwerkskamme2"
+        },
+        {
+            "name": "JUG-Kaiserslautern",
+            "url": "https://twitter.com/JUG_KL"
+        },
+        {
+            "name": "Chaos inKL.",
+            "url": "https://twitter.com/chaos_inkl"
+        }
+    ],
+    "sponsors": [
+        {
+            "name": "Avid",
+            "url": "https://twitter.com/Avid"
+        },
+        {
+            "name": "TOPdesk DE",
+            "url": "https://twitter.com/TOPdesk_DE"
+        },
+        {
+            "name": "EmpolisSoftware",
+            "url": "https://twitter.com/EmpolisSoftware"
+        }
+    ],
+    "title": "GDCR 2018 Kaiserslautern",
+    "url": "http://softwerkskammer-rlp.de/events/4/global-day-of-coderetreat/"
 }

--- a/_data/events_gdcr2018/Kalispell.json
+++ b/_data/events_gdcr2018/Kalispell.json
@@ -1,17 +1,20 @@
 {
-  "title": "Global Day of Coderetreat Kalispell",
-  "url": "https://www.meetup.com/Kalispell-Software-Crafters/events/255411817/",
-  "moderators": [
-    "@travislcraft"
-  ],
-  "location": {
-    "city": "Kalispell, MT",
-    "country": "United States of America",
-    "coordinates": {
-      "latitude": 48.1963841,
-      "longitude": -114.3130121
+    "location": {
+        "city": "Kalispell, MT",
+        "coordinates": {
+            "latitude": 48.1963841,
+            "longitude": -114.3130121
+        },
+        "country": "United States of America",
+        "timezone": "America/Denver",
+        "utcOffset": -7
     },
-    "utcOffset": -7,
-    "timezone": "America/Denver"
-  }
+    "moderators": [
+        {
+            "name": "Travis Craft",
+            "url": "https://twitter.com/travislcraft"
+        }
+    ],
+    "title": "Global Day of Coderetreat Kalispell",
+    "url": "https://www.meetup.com/Kalispell-Software-Crafters/events/255411817/"
 }

--- a/_data/events_gdcr2018/Karlsruhe.json
+++ b/_data/events_gdcr2018/Karlsruhe.json
@@ -1,19 +1,28 @@
 {
-  "title": "GDCR18 @fiducia_gad in Karlsruhe",
-  "url": "https://www.softwerkskammer.org/activities/ka-gdcr-18/",
-"moderators": [
-    "@ursmetz",
-    "@chr1shaefn3r",
-    "@petfic"
-  ],
-  "location": {
-    "city": "Karlsruhe",
-    "country": "Germany",
-    "coordinates": {
-      "latitude": 48.994277,
-      "longitude": 8.446993
+    "location": {
+        "city": "Karlsruhe",
+        "coordinates": {
+            "latitude": 48.994277,
+            "longitude": 8.446993
+        },
+        "country": "Germany",
+        "timezone": "Europe/Berlin",
+        "utcOffset": 1
     },
-    "utcOffset": 1,
-    "timezone": "Europe/Berlin"
-  }
+    "moderators": [
+        {
+            "name": "Urs Metz",
+            "url": "https://twitter.com/ursmetz"
+        },
+        {
+            "name": "Christoph H\u00e4fner",
+            "url": "https://twitter.com/chr1shaefn3r"
+        },
+        {
+            "name": "Peter Fichtner",
+            "url": "https://twitter.com/petfic"
+        }
+    ],
+    "title": "GDCR18 @fiducia_gad in Karlsruhe",
+    "url": "https://www.softwerkskammer.org/activities/ka-gdcr-18/"
 }

--- a/_data/events_gdcr2018/LasPalmas.json
+++ b/_data/events_gdcr2018/LasPalmas.json
@@ -1,17 +1,20 @@
 {
-  "title": "Global de Day del Codetreat Las Palmas",
-  "url": "https://www.meetup.com/es-ES/SPEGC-Sociedad-de-Promocion-Economica-de-Gran-Canaria/events/255766239/",
-  "moderators": [
-    "@godoyJonay"
-  ],
-  "location": {
-    "city": "Las Palmas",
-    "country": "Spain",
-    "coordinates": {
-      "latitude": 28.104595,
-      "longitude": -15.446427
+    "location": {
+        "city": "Las Palmas",
+        "coordinates": {
+            "latitude": 28.104595,
+            "longitude": -15.446427
+        },
+        "country": "Spain",
+        "timezone": "Africa/Casablanca",
+        "utcOffset": 1
     },
-    "utcOffset": 1,
-    "timezone": "Africa/Casablanca"
-  }
+    "moderators": [
+        {
+            "name": "Jonay Godoy",
+            "url": "https://twitter.com/godoyJonay"
+        }
+    ],
+    "title": "Global de Day del Codetreat Las Palmas",
+    "url": "https://www.meetup.com/es-ES/SPEGC-Sociedad-de-Promocion-Economica-de-Gran-Canaria/events/255766239/"
 }

--- a/_data/events_gdcr2018/Leipzig.json
+++ b/_data/events_gdcr2018/Leipzig.json
@@ -1,17 +1,20 @@
 {
-  "title": "GDCR 2018 in Leipzig @ Softwerkskammer Leipzig",
-  "url": "https://www.meetup.com/de-DE/Softwerkskammer-Leipzig/events/255699401",
-  "moderators": [
-    "@agebhar1"
-  ],
-  "location": {
-    "city": "Leipzig",
-    "country": "Germany",
-    "coordinates": {
-      "latitude": 51.3409,
-      "longitude": 12.3747
+    "location": {
+        "city": "Leipzig",
+        "coordinates": {
+            "latitude": 51.3409,
+            "longitude": 12.3747
+        },
+        "country": "Germany",
+        "timezone": "Europe/Berlin",
+        "utcOffset": 2
     },
-    "utcOffset": 2,
-    "timezone": "Europe/Berlin"
-  }
+    "moderators": [
+        {
+            "name": "Andreas Gebhardt",
+            "url": "https://twitter.com/agebhar1"
+        }
+    ],
+    "title": "GDCR 2018 in Leipzig @ Softwerkskammer Leipzig",
+    "url": "https://www.meetup.com/de-DE/Softwerkskammer-Leipzig/events/255699401"
 }

--- a/_data/events_gdcr2018/Lille.json
+++ b/_data/events_gdcr2018/Lille.json
@@ -1,21 +1,30 @@
 {
-  "title": "GDCR18 at Epitech in Lille",
-  "url": "https://www.meetup.com/fr-FR/Software-Craftsmanship-Lille/events/255208147/",
-  "moderators": [
-    "@6sko59",
-    "@jak78"
-  ],
-  "sponsors": [
-    "@octochti"
-  ],
-  "location": {
-    "city": "Lille",
-    "country": "France",
-    "coordinates": {
-      "latitude": 50.6333,
-      "longitude": 3.0667
+    "location": {
+        "city": "Lille",
+        "coordinates": {
+            "latitude": 50.6333,
+            "longitude": 3.0667
+        },
+        "country": "France",
+        "timezone": "Europe/Paris",
+        "utcOffset": 2
     },
-    "utcOffset": 2,
-    "timezone": "Europe/Paris"
-  }
+    "moderators": [
+        {
+            "name": "BACQUET Francis",
+            "url": "https://twitter.com/6sko59"
+        },
+        {
+            "name": "Julien Jakubowski",
+            "url": "https://twitter.com/jak78"
+        }
+    ],
+    "sponsors": [
+        {
+            "name": "OCTO Ch'ti",
+            "url": "https://twitter.com/octochti"
+        }
+    ],
+    "title": "GDCR18 at Epitech in Lille",
+    "url": "https://www.meetup.com/fr-FR/Software-Craftsmanship-Lille/events/255208147/"
 }

--- a/_data/events_gdcr2018/Ljubljana.json
+++ b/_data/events_gdcr2018/Ljubljana.json
@@ -1,16 +1,26 @@
 {
-  "title": "GDCR18 Ljubljana",
-  "url": "https://www.eventbrite.com/e/global-day-of-code-retreat-2018-ljubljana-by-bitstamp-tickets-52210974430",
-  "moderators": ["@edofic"],
-  "sponsors": ["@Bitstamp"],
-  "location": {
-    "city": "Ljubljana",
-    "country": "Slovenia",
-    "coordinates": {
-      "latitude": 46.052754,
-      "longitude": 14.5041763
+    "location": {
+        "city": "Ljubljana",
+        "coordinates": {
+            "latitude": 46.052754,
+            "longitude": 14.5041763
+        },
+        "country": "Slovenia",
+        "timezone": "Europe/Ljubljana",
+        "utcOffset": 2
     },
-    "utcOffset": 2,
-    "timezone": "Europe/Ljubljana"
-  }
+    "moderators": [
+        {
+            "name": "Andraz Bajt",
+            "url": "https://twitter.com/edofic"
+        }
+    ],
+    "sponsors": [
+        {
+            "name": "Bitstamp",
+            "url": "https://twitter.com/Bitstamp"
+        }
+    ],
+    "title": "GDCR18 Ljubljana",
+    "url": "https://www.eventbrite.com/e/global-day-of-code-retreat-2018-ljubljana-by-bitstamp-tickets-52210974430"
 }

--- a/_data/events_gdcr2018/Lodz.json
+++ b/_data/events_gdcr2018/Lodz.json
@@ -1,21 +1,30 @@
 {
-  "title": "GDCR18 in Lodz",
-  "url": "https://www.meetup.com/Java-User-Group-Lodz/events/255417647/",
-  "moderators": [
-    "@PawelWlodarski",
-    "@PiotrPrzybylak"
-  ],
-  "sponsors": [
-    "@Harman"
-  ],
-  "location": {
-    "city": "Łódź",
-    "country": "Poland",
-    "coordinates": {
-      "latitude": 51.7782253,
-      "longitude": 19.4524516
+    "location": {
+        "city": "\u0141\u00f3d\u017a",
+        "coordinates": {
+            "latitude": 51.7782253,
+            "longitude": 19.4524516
+        },
+        "country": "Poland",
+        "timezone": "Europe/Warsaw",
+        "utcOffset": 2
     },
-    "utcOffset": 2,
-    "timezone": "Europe/Warsaw"
-  }
+    "moderators": [
+        {
+            "name": "Pawe\u0142 W\u0142odarski",
+            "url": "https://twitter.com/PawelWlodarski"
+        },
+        {
+            "name": "Piotr Przybylak",
+            "url": "https://twitter.com/PiotrPrzybylak"
+        }
+    ],
+    "sponsors": [
+        {
+            "name": "HARMAN",
+            "url": "https://twitter.com/Harman"
+        }
+    ],
+    "title": "GDCR18 in Lodz",
+    "url": "https://www.meetup.com/Java-User-Group-Lodz/events/255417647/"
 }

--- a/_data/events_gdcr2018/Logrono.json
+++ b/_data/events_gdcr2018/Logrono.json
@@ -1,17 +1,20 @@
 {
-  "title": "GDCR18 in Logroño",
-  "url": "http://riojadotnet.com/eventos/global-day-of-coderetreat-2018",
-  "moderators": [
-    "@luissagasta"
-  ],
-  "location": {
-    "city": "Logroño",
-    "country": "Spain",
-    "coordinates": {
-      "latitude": 42.4607989,
-      "longitude": -2.4182367
+    "location": {
+        "city": "Logro\u00f1o",
+        "coordinates": {
+            "latitude": 42.4607989,
+            "longitude": -2.4182367
+        },
+        "country": "Spain",
+        "timezone": "Europe/Madrid",
+        "utcOffset": 2
     },
-    "utcOffset": 2,
-    "timezone": "Europe/Madrid"
-  }
+    "moderators": [
+        {
+            "name": "Luis Sagasta",
+            "url": "https://twitter.com/luissagasta"
+        }
+    ],
+    "title": "GDCR18 in Logro\u00f1o",
+    "url": "http://riojadotnet.com/eventos/global-day-of-coderetreat-2018"
 }

--- a/_data/events_gdcr2018/London-Codurance.json
+++ b/_data/events_gdcr2018/London-Codurance.json
@@ -1,19 +1,28 @@
 {
-  "title": "GDCR18 @Codurance London",
-  "url": "https://www.meetup.com/london-software-craftsmanship/events/255548337",
-  "moderators": [
-    "@yefoakira",
-    "@alfredodev",
-    "@rovout"
-  ],
-  "location": {
-    "city": "London",
-    "country": "United Kingdom",
-    "coordinates": {
-      "latitude": 51.524022,
-      "longitude": -0.100429
+    "location": {
+        "city": "London",
+        "coordinates": {
+            "latitude": 51.524022,
+            "longitude": -0.100429
+        },
+        "country": "United Kingdom",
+        "timezone": "Europe/London",
+        "utcOffset": 1
     },
-    "utcOffset": 1,
-    "timezone": "Europe/London"
-  }
+    "moderators": [
+        {
+            "name": "Jorge Gueorguiev",
+            "url": "https://twitter.com/yefoakira"
+        },
+        {
+            "name": "Alfredo Fern\u00e1ndez",
+            "url": "https://twitter.com/alfredodev"
+        },
+        {
+            "name": "@rovout",
+            "url": "https://twitter.com/rovout"
+        }
+    ],
+    "title": "GDCR18 @Codurance London",
+    "url": "https://www.meetup.com/london-software-craftsmanship/events/255548337"
 }

--- a/_data/events_gdcr2018/London-GDS.json
+++ b/_data/events_gdcr2018/London-GDS.json
@@ -1,18 +1,24 @@
 {
-  "title": "GDCR18 @GDS London",
-  "url": "https://www.eventbrite.com/e/global-day-of-coderetreat-at-gds-london-tickets-52153436332",
-  "moderators": [
-    "@georgeracu",
-    "@dgheath21"
-  ],
-  "location": {
-    "city": "London",
-    "country": "United Kingdom",
-    "coordinates": {
-      "latitude": 51.5144006,
-      "longitude": -0.0752186
+    "location": {
+        "city": "London",
+        "coordinates": {
+            "latitude": 51.5144006,
+            "longitude": -0.0752186
+        },
+        "country": "United Kingdom",
+        "timezone": "Europe/London",
+        "utcOffset": 1
     },
-    "utcOffset": 1,
-    "timezone": "Europe/London"
-  }
+    "moderators": [
+        {
+            "name": "George Racu",
+            "url": "https://twitter.com/georgeracu"
+        },
+        {
+            "name": "David Heath",
+            "url": "https://twitter.com/dgheath21"
+        }
+    ],
+    "title": "GDCR18 @GDS London",
+    "url": "https://www.eventbrite.com/e/global-day-of-coderetreat-at-gds-london-tickets-52153436332"
 }

--- a/_data/events_gdcr2018/London-Makers.json
+++ b/_data/events_gdcr2018/London-Makers.json
@@ -1,21 +1,28 @@
 {
-  "title": "GDCR 2018 at Makers Academy",
-  "url": "https://www.eventbrite.co.uk/e/global-day-of-coderetreat-tickets-51453845838",
-  "moderators": [
-    "Agnes Donat",
-    "Marco Passuello"
-  ],
-  "sponsors": [
-    "@makersacademy"
-  ],
-  "location": {
-    "city": "London",
-    "country": "United Kingdom",
-    "coordinates": {
-      "latitude": 51.51728,
-      "longitude": -0.07362
+    "location": {
+        "city": "London",
+        "coordinates": {
+            "latitude": 51.51728,
+            "longitude": -0.07362
+        },
+        "country": "United Kingdom",
+        "timezone": "Europe/London",
+        "utcOffset": 0
     },
-    "utcOffset": 0,
-    "timezone": "Europe/London"
-  }
+    "moderators": [
+        {
+            "name": "Agnes Donat"
+        },
+        {
+            "name": "Marco Passuello"
+        }
+    ],
+    "sponsors": [
+        {
+            "name": "Makers",
+            "url": "https://twitter.com/makersacademy"
+        }
+    ],
+    "title": "GDCR 2018 at Makers Academy",
+    "url": "https://www.eventbrite.co.uk/e/global-day-of-coderetreat-tickets-51453845838"
 }

--- a/_data/events_gdcr2018/London.json
+++ b/_data/events_gdcr2018/London.json
@@ -1,20 +1,25 @@
 {
-  "title": "GDCR 2018 in London",
-  "url": "https://www.eventbrite.com/e/global-day-of-coderetreat-london-tickets-51028736324",
-  "moderators": [
-    "@mmhanif"
-  ],
-  "sponsors": [
-    "J.P. Morgan"
-  ],
-  "location": {
-    "city": "London",
-    "country": "United Kingdom",
-    "coordinates": {
-      "latitude": 51.5122022,
-      "longitude": -0.1084704
+    "location": {
+        "city": "London",
+        "coordinates": {
+            "latitude": 51.5122022,
+            "longitude": -0.1084704
+        },
+        "country": "United Kingdom",
+        "timezone": "Europe/London",
+        "utcOffset": 0
     },
-    "utcOffset": 0,
-    "timezone": "Europe/London"
-  }
+    "moderators": [
+        {
+            "name": "mmhanif",
+            "url": "https://twitter.com/mmhanif"
+        }
+    ],
+    "sponsors": [
+        {
+            "name": "J.P. Morgan"
+        }
+    ],
+    "title": "GDCR 2018 in London",
+    "url": "https://www.eventbrite.com/e/global-day-of-coderetreat-london-tickets-51028736324"
 }

--- a/_data/events_gdcr2018/LosAngeles.json
+++ b/_data/events_gdcr2018/LosAngeles.json
@@ -1,21 +1,33 @@
 {
-  "title": "GDCR18 in Downtown Los Angeles, CA, USA",
-  "url": "https://www.meetup.com/PolyglotLA/events/255379239/",
-  "moderators": [
-    "@PolyglotLA",
-    "@_IanDCarroll_",
-    "@RayHightower"
-  ],
-  "sponsors": [
-    "@8thLightInc"
-  ],
-  "location": {
-    "city": "Los Angeles",
-    "country": "United States of America",
-    "coordinates": {
-      "latitude": 34.0522,
-      "longitude": -118.2437
+    "location": {
+        "city": "Los Angeles",
+        "coordinates": {
+            "latitude": 34.0522,
+            "longitude": -118.2437
+        },
+        "country": "United States of America",
+        "timezone": "America/Los_Angeles"
     },
-    "timezone": "America/Los_Angeles"
-  }
+    "moderators": [
+        {
+            "name": "Polyglot.LA",
+            "url": "https://twitter.com/PolyglotLA"
+        },
+        {
+            "name": "Ian Carroll",
+            "url": "https://twitter.com/_IanDCarroll_"
+        },
+        {
+            "name": "Raymond T. Hightower",
+            "url": "https://twitter.com/RayHightower"
+        }
+    ],
+    "sponsors": [
+        {
+            "name": "8th Light",
+            "url": "https://twitter.com/8thLightInc"
+        }
+    ],
+    "title": "GDCR18 in Downtown Los Angeles, CA, USA",
+    "url": "https://www.meetup.com/PolyglotLA/events/255379239/"
 }

--- a/_data/events_gdcr2018/Luebeck.json
+++ b/_data/events_gdcr2018/Luebeck.json
@@ -1,20 +1,26 @@
 {
-  "title": "GDCR 2018 @ Draeger",
-  "url": "http://meetu.ps/e/FPPgJ/tTkLh/f",
-  "moderators": [
-    "@badbadc0ffee"
-  ],
-  "sponsors": [
-    "@DraegerNews"
-  ],
-  "location": {
-    "city": "Luebeck",
-    "country": "Germany",
-    "coordinates": {
-      "latitude": 53.855961,
-      "longitude": 10.6711248
+    "location": {
+        "city": "Luebeck",
+        "coordinates": {
+            "latitude": 53.855961,
+            "longitude": 10.6711248
+        },
+        "country": "Germany",
+        "timezone": "Europe/Berlin",
+        "utcOffset": 1
     },
-    "utcOffset": 1,
-    "timezone": "Europe/Berlin"
-  }
+    "moderators": [
+        {
+            "name": "Florian \u2615",
+            "url": "https://twitter.com/badbadc0ffee"
+        }
+    ],
+    "sponsors": [
+        {
+            "name": "Dr\u00e4ger",
+            "url": "https://twitter.com/DraegerNews"
+        }
+    ],
+    "title": "GDCR 2018 @ Draeger",
+    "url": "http://meetu.ps/e/FPPgJ/tTkLh/f"
 }

--- a/_data/events_gdcr2018/Luzern.json
+++ b/_data/events_gdcr2018/Luzern.json
@@ -1,17 +1,20 @@
 {
-  "title": "GDCR18 in Luzern",
-  "url": "https://zurich.codersonly.org/events/code-retreat/",
-  "moderators": [
-    "@marcoravicini"
-  ],
-  "location": {
-    "city": "Luzern",
-    "country": "Switzerland",
-    "coordinates": {
-      "latitude": 47.063683,
-      "longitude": 8.310984
+    "location": {
+        "city": "Luzern",
+        "coordinates": {
+            "latitude": 47.063683,
+            "longitude": 8.310984
+        },
+        "country": "Switzerland",
+        "timezone": "Europe/Zurich",
+        "utcOffset": 2
     },
-    "utcOffset": 2,
-    "timezone": "Europe/Zurich"
-  }
+    "moderators": [
+        {
+            "name": "Marco Ravicini",
+            "url": "https://twitter.com/marcoravicini"
+        }
+    ],
+    "title": "GDCR18 in Luzern",
+    "url": "https://zurich.codersonly.org/events/code-retreat/"
 }

--- a/_data/events_gdcr2018/Lyon.json
+++ b/_data/events_gdcr2018/Lyon.json
@@ -1,18 +1,24 @@
 {
-  "title": "GDCR18 in Lyon",
-  "url": "https://www.meetup.com/fr-FR/Software-Craftsmanship-Lyon/events/255320937/",
-  "moderators": [
-    "@saby_nastasia",
-    "@RomainTrm"
-  ],
-  "location": {
-    "city": "Lyon",
-    "country": "France",
-    "coordinates": {
-      "latitude": 45.7621772,
-      "longitude": 4.8600658
+    "location": {
+        "city": "Lyon",
+        "coordinates": {
+            "latitude": 45.7621772,
+            "longitude": 4.8600658
+        },
+        "country": "France",
+        "timezone": "Europe/Paris",
+        "utcOffset": 2
     },
-    "utcOffset": 2,
-    "timezone": "Europe/Paris"
-  }
+    "moderators": [
+        {
+            "name": "nastasia saby",
+            "url": "https://twitter.com/saby_nastasia"
+        },
+        {
+            "name": "Romain Berthon",
+            "url": "https://twitter.com/RomainTrm"
+        }
+    ],
+    "title": "GDCR18 in Lyon",
+    "url": "https://www.meetup.com/fr-FR/Software-Craftsmanship-Lyon/events/255320937/"
 }

--- a/_data/events_gdcr2018/MUNICH-HOLIDU.json
+++ b/_data/events_gdcr2018/MUNICH-HOLIDU.json
@@ -1,18 +1,24 @@
 {
-  "title": "GDCR18 Munich at Holidu",
-  "url": "https://www.eventbrite.com/e/gdcr18-munich-at-holidu-tickets-50589075286",
-  "moderators": [
-    "@goosebumps4",
-    "@ddanielbee"
-  ],
-  "location": {
-    "city": "Munich",
-    "country": "Germany",
-    "coordinates": {
-      "latitude": 48.178925,
-      "longitude": 11.538115
+    "location": {
+        "city": "Munich",
+        "coordinates": {
+            "latitude": 48.178925,
+            "longitude": 11.538115
+        },
+        "country": "Germany",
+        "timezone": "Europe/Berlin",
+        "utcOffset": 1
     },
-    "utcOffset": 1,
-    "timezone": "Europe/Berlin"
-  }
+    "moderators": [
+        {
+            "name": "Andrei Bechet",
+            "url": "https://twitter.com/goosebumps4"
+        },
+        {
+            "name": "Daniel Bol\u00edvar",
+            "url": "https://twitter.com/ddanielbee"
+        }
+    ],
+    "title": "GDCR18 Munich at Holidu",
+    "url": "https://www.eventbrite.com/e/gdcr18-munich-at-holidu-tickets-50589075286"
 }

--- a/_data/events_gdcr2018/Malaga.json
+++ b/_data/events_gdcr2018/Malaga.json
@@ -1,20 +1,25 @@
 {
-  "title": "GDCR18 in Málaga",
-  "url": "https://www.meetup.com/MalagaJUG/events/248220933/",
-  "moderators": [
-    "@MalagaJUG"
-  ],
-  "sponsors": [
-    "theworkshop.com"
-  ],
-  "location": {
-    "city": "Málaga",
-    "country": "Spain",
-    "coordinates": {
-      "latitude": 36.718339,
-      "longitude": -4.5194787
+    "location": {
+        "city": "M\u00e1laga",
+        "coordinates": {
+            "latitude": 36.718339,
+            "longitude": -4.5194787
+        },
+        "country": "Spain",
+        "timezone": "Europe/Madrid",
+        "utcOffset": 2
     },
-    "utcOffset": 2,
-    "timezone": "Europe/Madrid"
-  }
+    "moderators": [
+        {
+            "name": "M\u00e1laga JUG",
+            "url": "https://twitter.com/MalagaJUG"
+        }
+    ],
+    "sponsors": [
+        {
+            "name": "theworkshop.com"
+        }
+    ],
+    "title": "GDCR18 in M\u00e1laga",
+    "url": "https://www.meetup.com/MalagaJUG/events/248220933/"
 }

--- a/_data/events_gdcr2018/Matsuyama.json
+++ b/_data/events_gdcr2018/Matsuyama.json
@@ -1,17 +1,20 @@
 {
-  "title": "GDCR 2018 in Matsuyama",
-  "url": "https://agile459.connpass.com/event/104737/",
-  "moderators": [
-    "@ramusara"
-  ],
-  "location": {
-    "city": "Matsuyama",
-    "country": "Japan",
-    "coordinates": {
-      "latitude": 33.8368383,
-      "longitude": 132.7654169
+    "location": {
+        "city": "Matsuyama",
+        "coordinates": {
+            "latitude": 33.8368383,
+            "longitude": 132.7654169
+        },
+        "country": "Japan",
+        "timezone": "Asia/Tokyo",
+        "utcOffset": 9
     },
-    "utcOffset": 9,
-    "timezone": "Asia/Tokyo"
-  }
+    "moderators": [
+        {
+            "name": "(\uff03\uff3e\u03c9\uff3e)\uff97\uff91\uff97\uff91",
+            "url": "https://twitter.com/ramusara"
+        }
+    ],
+    "title": "GDCR 2018 in Matsuyama",
+    "url": "https://agile459.connpass.com/event/104737/"
 }

--- a/_data/events_gdcr2018/Melbourne.json
+++ b/_data/events_gdcr2018/Melbourne.json
@@ -1,23 +1,38 @@
 {
-  "title": "#gdcr Melbourne 2018",
-  "url": "https://www.eventbrite.com.au/e/global-day-of-coderetreat-gdcr-melbourne-2018-tickets-45418129849",
-  "moderators": [
-    "@erdbeervogel",
-    "@thelukemccarthy"
-  ],
-  "sponsors": [
-    "@seekjobs",
-    "@thoughtworks",
-    "@REA_Group"
-  ],
-  "location": {
-    "city": "Melbourne",
-    "country": "Australia",
-    "coordinates": {
-      "latitude": -37.846167,
-      "longitude": 144.979726
+    "location": {
+        "city": "Melbourne",
+        "coordinates": {
+            "latitude": -37.846167,
+            "longitude": 144.979726
+        },
+        "country": "Australia",
+        "timezone": "Australia/Melbourne",
+        "utcOffset": 10
     },
-    "utcOffset": 10,
-    "timezone": "Australia/Melbourne"
-  }
+    "moderators": [
+        {
+            "name": "Victoria Schiffer",
+            "url": "https://twitter.com/erdbeervogel"
+        },
+        {
+            "name": "Luke McCarthy",
+            "url": "https://twitter.com/thelukemccarthy"
+        }
+    ],
+    "sponsors": [
+        {
+            "name": "SEEK",
+            "url": "https://twitter.com/seekjobs"
+        },
+        {
+            "name": "ThoughtWorks",
+            "url": "https://twitter.com/thoughtworks"
+        },
+        {
+            "name": "REA Group",
+            "url": "https://twitter.com/REA_Group"
+        }
+    ],
+    "title": "#gdcr Melbourne 2018",
+    "url": "https://www.eventbrite.com.au/e/global-day-of-coderetreat-gdcr-melbourne-2018-tickets-45418129849"
 }

--- a/_data/events_gdcr2018/Minsk.json
+++ b/_data/events_gdcr2018/Minsk.json
@@ -1,19 +1,28 @@
 {
-  "title": "GDCR18 in Minsk",
-  "url": "https://goo.gl/forms/XnBuav7MgN863rkR2",
-  "moderators": [
-    "@AlenaKudravets",
-    "@allomov", 
-    "@Sergyenko"
-  ],
-  "location": {
-    "city": "Minsk",
-    "country": "Belarus",
-    "coordinates": {
-      "latitude": 53.9004681,
-      "longitude": 27.5393772
+    "location": {
+        "city": "Minsk",
+        "coordinates": {
+            "latitude": 53.9004681,
+            "longitude": 27.5393772
+        },
+        "country": "Belarus",
+        "timezone": "Europe/Minsk",
+        "utcOffset": 3
     },
-    "utcOffset": 3,
-    "timezone": "Europe/Minsk"
-  }
+    "moderators": [
+        {
+            "name": "@AlenaKudravets",
+            "url": "https://twitter.com/AlenaKudravets"
+        },
+        {
+            "name": "Allomov",
+            "url": "https://twitter.com/allomov"
+        },
+        {
+            "name": "Sergey Sergy\u0435nko",
+            "url": "https://twitter.com/Sergyenko"
+        }
+    ],
+    "title": "GDCR18 in Minsk",
+    "url": "https://goo.gl/forms/XnBuav7MgN863rkR2"
 }

--- a/_data/events_gdcr2018/Montreal.json
+++ b/_data/events_gdcr2018/Montreal.json
@@ -1,17 +1,20 @@
 {
-  "title": "GDCR 2018 Montréal @ Busbud",
-  "url": "https://www.eventbrite.fr/e/billets-global-day-of-code-retreat-busbud-montreal-50503091105",
-  "moderators": [
-    "@nicoespeon"
-  ],
-  "location": {
-    "city": "Montreal",
-    "country": "Canada",
-    "coordinates": {
-      "latitude": 45.52651,
-      "longitude": -73.59632
+    "location": {
+        "city": "Montreal",
+        "coordinates": {
+            "latitude": 45.52651,
+            "longitude": -73.59632
+        },
+        "country": "Canada",
+        "timezone": "America/Montreal",
+        "utcOffset": -4
     },
-    "utcOffset": -4,
-    "timezone": "America/Montreal"
-  }
+    "moderators": [
+        {
+            "name": "Nicolas Carlo",
+            "url": "https://twitter.com/nicoespeon"
+        }
+    ],
+    "title": "GDCR 2018 Montr\u00e9al @ Busbud",
+    "url": "https://www.eventbrite.fr/e/billets-global-day-of-code-retreat-busbud-montreal-50503091105"
 }

--- a/_data/events_gdcr2018/Muenster.json
+++ b/_data/events_gdcr2018/Muenster.json
@@ -1,17 +1,20 @@
 {
-  "title": "GDCR18 @fiducia_gad in Münster",
-  "url": "https://www.softwerkskammer.org/activities/ms-gdcr-18/",
-  "moderators": [
-    "@ndrssmn"
-  ],
-  "location": {
-    "city": "Münster",
-    "country": "Germany",
-    "coordinates": {
-      "latitude": 51.933996,
-      "longitude": 7.587291
+    "location": {
+        "city": "M\u00fcnster",
+        "coordinates": {
+            "latitude": 51.933996,
+            "longitude": 7.587291
+        },
+        "country": "Germany",
+        "timezone": "Europe/Berlin",
+        "utcOffset": 1
     },
-    "utcOffset": 1,
-    "timezone": "Europe/Berlin"
-  }
+    "moderators": [
+        {
+            "name": "Andreas Simon",
+            "url": "https://twitter.com/ndrssmn"
+        }
+    ],
+    "title": "GDCR18 @fiducia_gad in M\u00fcnster",
+    "url": "https://www.softwerkskammer.org/activities/ms-gdcr-18/"
 }

--- a/_data/events_gdcr2018/Mumbai-Media.net.json
+++ b/_data/events_gdcr2018/Mumbai-Media.net.json
@@ -1,21 +1,29 @@
 {
-  "title": "GDCR18 @ Media.net, Mumbai",
-  "url": "https://goo.gl/yUA1sX",
-  "moderators": [
-    "@vedantseta",
-    "@sandeepshetty"
-  ],
-"sponsors": [
-    "Media.net"
-],
-  "location": {
-    "city": "Mumbai",
-    "country": "India",
-    "coordinates": {
-      "latitude": 19.124681,
-      "longitude": 72.8463366
+    "location": {
+        "city": "Mumbai",
+        "coordinates": {
+            "latitude": 19.124681,
+            "longitude": 72.8463366
+        },
+        "country": "India",
+        "timezone": "Asia/Kolkata",
+        "utcOffset": 5.5
     },
-   "utcOffset": 5.5,
-   "timezone": "Asia/Kolkata"
-  }
+    "moderators": [
+        {
+            "name": "Vedant Seta",
+            "url": "https://twitter.com/vedantseta"
+        },
+        {
+            "name": "Sandeep Shetty",
+            "url": "https://twitter.com/sandeepshetty"
+        }
+    ],
+    "sponsors": [
+        {
+            "name": "Media.net"
+        }
+    ],
+    "title": "GDCR18 @ Media.net, Mumbai",
+    "url": "https://goo.gl/yUA1sX"
 }

--- a/_data/events_gdcr2018/Munich.json
+++ b/_data/events_gdcr2018/Munich.json
@@ -1,17 +1,20 @@
 {
-  "title": "Global Day of Code Retreat 2018 in Munich",
-  "url": "https://www.meetup.com/munich-software-craft-community/events/254658206/",
-  "moderators": [
-    "@davidvoelkel"
-  ],
-  "location": {
-    "city": "Munich",
-    "country": "Germany",
-    "coordinates": {
-      "latitude": 48.125256,
-      "longitude": 11.588901
+    "location": {
+        "city": "Munich",
+        "coordinates": {
+            "latitude": 48.125256,
+            "longitude": 11.588901
+        },
+        "country": "Germany",
+        "timezone": "Europe/Berlin",
+        "utcOffset": 2
     },
-    "utcOffset": 2,
-    "timezone": "Europe/Berlin"
-  }
+    "moderators": [
+        {
+            "name": "David V\u00f6lkel",
+            "url": "https://twitter.com/davidvoelkel"
+        }
+    ],
+    "title": "Global Day of Code Retreat 2018 in Munich",
+    "url": "https://www.meetup.com/munich-software-craft-community/events/254658206/"
 }

--- a/_data/events_gdcr2018/Nantes.json
+++ b/_data/events_gdcr2018/Nantes.json
@@ -1,23 +1,38 @@
 {
-  "title": "GDCR18 at Dojo in Nantes",
-  "url": "https://www.meetup.com/fr-FR/nantes-software-crafters-Nantes/events/255678035/",
-  "moderators": [
-    "@sebfauvel",
-    "@CeciliaBossard",
-    "@jpalies",
-    "@__MaxS__"
-  ],
-  "sponsors": [
-    "@PALO_IT_Nantes"
-  ],
-  "location": {
-    "city": "Nantes",
-    "country": "France",
-    "coordinates": {
-      "latitude": 47.217959,
-      "longitude": -1.5451488
+    "location": {
+        "city": "Nantes",
+        "coordinates": {
+            "latitude": 47.217959,
+            "longitude": -1.5451488
+        },
+        "country": "France",
+        "timezone": "Europe/Paris",
+        "utcOffset": 2
     },
-    "utcOffset": 2,
-    "timezone": "Europe/Paris"
-  }
+    "moderators": [
+        {
+            "name": "Fauvel S\u00e9bastien",
+            "url": "https://twitter.com/sebfauvel"
+        },
+        {
+            "name": "C\u00e9cilia Bossard",
+            "url": "https://twitter.com/CeciliaBossard"
+        },
+        {
+            "name": "Jean Pali\u00e8s",
+            "url": "https://twitter.com/jpalies"
+        },
+        {
+            "name": "Maxime SC",
+            "url": "https://twitter.com/__MaxS__"
+        }
+    ],
+    "sponsors": [
+        {
+            "name": "PALO IT Nantes",
+            "url": "https://twitter.com/PALO_IT_Nantes"
+        }
+    ],
+    "title": "GDCR18 at Dojo in Nantes",
+    "url": "https://www.meetup.com/fr-FR/nantes-software-crafters-Nantes/events/255678035/"
 }

--- a/_data/events_gdcr2018/Nuernberg.json
+++ b/_data/events_gdcr2018/Nuernberg.json
@@ -1,20 +1,25 @@
 {
-  "title": "GDCR 2018 @ MATHEMA",
-  "url": "https://www.mathema.de/veranstaltungen/global-day-of-coderetreat-2018",
-  "moderators": [
-    "Nico"
-  ],
-    "sponsors": [
-    "@MATHEMA123"
-  ],
-  "location": {
-    "city": "Nürnberg",
-    "country": "Germany",
-    "coordinates": {
-      "latitude": 49.4644076,
-      "longitude": 11.0838987
+    "location": {
+        "city": "N\u00fcrnberg",
+        "coordinates": {
+            "latitude": 49.4644076,
+            "longitude": 11.0838987
+        },
+        "country": "Germany",
+        "timezone": "Europe/Berlin",
+        "utcOffset": 1
     },
-    "utcOffset": 1,
-    "timezone": "Europe/Berlin"
-  }
+    "moderators": [
+        {
+            "name": "Nico"
+        }
+    ],
+    "sponsors": [
+        {
+            "name": "MATHEMA Software GmbH",
+            "url": "https://twitter.com/MATHEMA123"
+        }
+    ],
+    "title": "GDCR 2018 @ MATHEMA",
+    "url": "https://www.mathema.de/veranstaltungen/global-day-of-coderetreat-2018"
 }

--- a/_data/events_gdcr2018/Nuremberg.json
+++ b/_data/events_gdcr2018/Nuremberg.json
@@ -1,24 +1,42 @@
 {
-  "title": "GDCR 2018 @ DATEV",
-  "url": "https://ti.to/gdcr-nuernberg/2018",
-  "moderators": [
-    "@Fischermaen",
-    "@XelamRelos",
-    "@marcoemrich",
-    "@embedjourneyman"
-  ],
-  "sponsors": [
-    "@SCC_at_DATEV",
-    "@DATEV"
-  ],
-  "location": {
-    "city": "Nuremberg",
-    "country": "Germany",
-    "coordinates": {
-      "latitude": 49.45311,
-      "longitude": 11.04607
+    "location": {
+        "city": "Nuremberg",
+        "coordinates": {
+            "latitude": 49.45311,
+            "longitude": 11.04607
+        },
+        "country": "Germany",
+        "timezone": "Europe/Berlin",
+        "utcOffset": 1
     },
-    "utcOffset": 1,
-    "timezone": "Europe/Berlin"
-  }
+    "moderators": [
+        {
+            "name": "Andy Fischer",
+            "url": "https://twitter.com/Fischermaen"
+        },
+        {
+            "name": "Alex Soler Sanandres",
+            "url": "https://twitter.com/XelamRelos"
+        },
+        {
+            "name": "Marco Emrich",
+            "url": "https://twitter.com/marcoemrich"
+        },
+        {
+            "name": "Ren\u00e9 F\u00fcger",
+            "url": "https://twitter.com/embedjourneyman"
+        }
+    ],
+    "sponsors": [
+        {
+            "name": "SCC @ DATEV",
+            "url": "https://twitter.com/SCC_at_DATEV"
+        },
+        {
+            "name": "DATEV",
+            "url": "https://twitter.com/DATEV"
+        }
+    ],
+    "title": "GDCR 2018 @ DATEV",
+    "url": "https://ti.to/gdcr-nuernberg/2018"
 }

--- a/_data/events_gdcr2018/Osaka.json
+++ b/_data/events_gdcr2018/Osaka.json
@@ -1,17 +1,20 @@
 {
-  "title": "Global Day of Coderetreat 2018 in Osaka",
-  "url": "https://connpass.com/event/105117/",
-  "moderators": [
-    "@kawakawa"
-  ],
-  "location": {
-    "city": "Osaka",
-    "country": "Japan",
-    "coordinates": {
-      "latitude": 34.7018561,
-      "longitude": 135.5098518
+    "location": {
+        "city": "Osaka",
+        "coordinates": {
+            "latitude": 34.7018561,
+            "longitude": 135.5098518
+        },
+        "country": "Japan",
+        "timezone": "Asia/Tokyo",
+        "utcOffset": 9
     },
-    "utcOffset": 9,
-    "timezone": "Asia/Tokyo"
-  }
+    "moderators": [
+        {
+            "name": "\u304b\u308f\u3079\u3000\u305f\u304f\u3084",
+            "url": "https://twitter.com/kawakawa"
+        }
+    ],
+    "title": "Global Day of Coderetreat 2018 in Osaka",
+    "url": "https://connpass.com/event/105117/"
 }

--- a/_data/events_gdcr2018/Palma.json
+++ b/_data/events_gdcr2018/Palma.json
@@ -1,20 +1,26 @@
 {
-  "title": "GDCR18 Mallorca",
-  "url": "https://www.meetup.com/Mallorca-Software-Craftsmanship/",
-  "moderators": [
-    "@scmallorca"
-  ],
-  "sponsors": [
-    "@fdsaprogramacio"
-  ],
-  "location": {
-    "city": "Palma",
-    "country": "Spain",
-    "coordinates": {
-      "latitude": 39.580959,
-      "longitude": 2.649000
+    "location": {
+        "city": "Palma",
+        "coordinates": {
+            "latitude": 39.580959,
+            "longitude": 2.649
+        },
+        "country": "Spain",
+        "timezone": "Europe/Madrid",
+        "utcOffset": 2
     },
-    "utcOffset": 2,
-    "timezone": "Europe/Madrid"
-  }
+    "moderators": [
+        {
+            "name": "Mallorca SW Craft",
+            "url": "https://twitter.com/scmallorca"
+        }
+    ],
+    "sponsors": [
+        {
+            "name": "FDSA programaci\u00f3n",
+            "url": "https://twitter.com/fdsaprogramacio"
+        }
+    ],
+    "title": "GDCR18 Mallorca",
+    "url": "https://www.meetup.com/Mallorca-Software-Craftsmanship/"
 }

--- a/_data/events_gdcr2018/Pamplona.json
+++ b/_data/events_gdcr2018/Pamplona.json
@@ -1,20 +1,26 @@
 {
-  "title": "Global Day of Coderetreat 2018 in Pamplona, facilitated by Openbravo",
-  "url": "https://www.eventbrite.es/e/entradas-openbravo-coderetreat-2018-pair-programming-tdd-y-buenas-practicas-de-desarrollo-51963867326",
-  "moderators": [
-    "@AugustoMauch"
-  ],
-  "sponsors": [
-    "@Openbravo"
-  ],
-  "location": {
-    "city": "Mutilva",
-    "country": "Spain",
-    "coordinates": {
-      "latitude": 42.79674389424998,
-      "longitude": -1.6133970022189033
+    "location": {
+        "city": "Mutilva",
+        "coordinates": {
+            "latitude": 42.79674389424998,
+            "longitude": -1.6133970022189033
+        },
+        "country": "Spain",
+        "timezone": "Europe/Madrid",
+        "utcOffset": 2
     },
-    "utcOffset": 2,
-    "timezone": "Europe/Madrid"
-  }
+    "moderators": [
+        {
+            "name": "Augusto Mauch",
+            "url": "https://twitter.com/AugustoMauch"
+        }
+    ],
+    "sponsors": [
+        {
+            "name": "Openbravo",
+            "url": "https://twitter.com/Openbravo"
+        }
+    ],
+    "title": "Global Day of Coderetreat 2018 in Pamplona, facilitated by Openbravo",
+    "url": "https://www.eventbrite.es/e/entradas-openbravo-coderetreat-2018-pair-programming-tdd-y-buenas-practicas-de-desarrollo-51963867326"
 }

--- a/_data/events_gdcr2018/Paris-soat.json
+++ b/_data/events_gdcr2018/Paris-soat.json
@@ -1,21 +1,30 @@
 {
-  "title": "GDCR18 at SOAT in Paris",
-  "url": "https://www.meetup.com/paris-software-craftsmanship/events/255446863/",
-  "moderators": [
-    "@michelle_avomo",
-    "@XDetant"
-  ],
-  "sponsors": [
-    "@SoatGroup"
-  ],
-  "location": {
-    "city": "Paris",
-    "country": "France",
-    "coordinates": {
-      "latitude": 48.8639164,
-      "longitude": 2.3390189
+    "location": {
+        "city": "Paris",
+        "coordinates": {
+            "latitude": 48.8639164,
+            "longitude": 2.3390189
+        },
+        "country": "France",
+        "timezone": "Europe/Paris",
+        "utcOffset": 2
     },
-    "utcOffset": 2,
-    "timezone": "Europe/Paris"
-  }
+    "moderators": [
+        {
+            "name": "Michelle",
+            "url": "https://twitter.com/michelle_avomo"
+        },
+        {
+            "name": "Xavier Detant",
+            "url": "https://twitter.com/XDetant"
+        }
+    ],
+    "sponsors": [
+        {
+            "name": "SOAT",
+            "url": "https://twitter.com/SoatGroup"
+        }
+    ],
+    "title": "GDCR18 at SOAT in Paris",
+    "url": "https://www.meetup.com/paris-software-craftsmanship/events/255446863/"
 }

--- a/_data/events_gdcr2018/Paris.json
+++ b/_data/events_gdcr2018/Paris.json
@@ -1,21 +1,30 @@
 {
-  "title": "GDCR18 at Arolla in Paris",
-  "url": "https://www.meetup.com/fr-FR/paris-software-craftsmanship/events/255058916/",
-  "moderators": [
-    "@DorraBartaguiz",
-    "@somabrouki"
-  ],
-  "sponsors": [
-    "@arollaFr"
-  ],
-  "location": {
-    "city": "Paris",
-    "country": "France",
-    "coordinates": {
-      "latitude": 48.8639164,
-      "longitude": 2.3390189
+    "location": {
+        "city": "Paris",
+        "coordinates": {
+            "latitude": 48.8639164,
+            "longitude": 2.3390189
+        },
+        "country": "France",
+        "timezone": "Europe/Paris",
+        "utcOffset": 2
     },
-    "utcOffset": 2,
-    "timezone": "Europe/Paris"
-  }
+    "moderators": [
+        {
+            "name": "Dorra Bartaguiz",
+            "url": "https://twitter.com/DorraBartaguiz"
+        },
+        {
+            "name": "Olfa Mabrouki",
+            "url": "https://twitter.com/somabrouki"
+        }
+    ],
+    "sponsors": [
+        {
+            "name": "Arolla",
+            "url": "https://twitter.com/arollaFr"
+        }
+    ],
+    "title": "GDCR18 at Arolla in Paris",
+    "url": "https://www.meetup.com/fr-FR/paris-software-craftsmanship/events/255058916/"
 }

--- a/_data/events_gdcr2018/Philadelphia.json
+++ b/_data/events_gdcr2018/Philadelphia.json
@@ -1,17 +1,20 @@
 {
-  "title": "Global Day of Coderetreat 2018 in Philadelphia",
-  "url": "https://www.meetup.com/Software-as-Craft-Philadelphia/events/256078155/",
-  "moderators": [
-    "@samjonester"
-  ],
-  "location": {
-    "city": "Philadelphia",
-    "country": "United States of America",
-    "coordinates": {
-      "latitude": 39.952372,
-      "longitude": -75.145024
+    "location": {
+        "city": "Philadelphia",
+        "coordinates": {
+            "latitude": 39.952372,
+            "longitude": -75.145024
+        },
+        "country": "United States of America",
+        "timezone": "America/New_York",
+        "utcOffset": -5
     },
-    "utcOffset": -5,
-    "timezone": "America/New_York"
-  }
+    "moderators": [
+        {
+            "name": "Sam Jones",
+            "url": "https://twitter.com/samjonester"
+        }
+    ],
+    "title": "Global Day of Coderetreat 2018 in Philadelphia",
+    "url": "https://www.meetup.com/Software-as-Craft-Philadelphia/events/256078155/"
 }

--- a/_data/events_gdcr2018/Pittsburgh.json
+++ b/_data/events_gdcr2018/Pittsburgh.json
@@ -1,18 +1,24 @@
 {
-  "title": "GDCR2018 Pittsburgh",
-  "url": "https://www.meetup.com/Pittsburgh-Code-Supply/events/253736933/",
-  "moderators": [
-    "@colindean",
-    "@justinreese"
-  ],
-  "location": {
-    "city": "Pittsburgh",
-    "country": "United States of America",
-    "coordinates": {
-      "latitude": 40.4599756,
-      "longitude": -79.9308717
+    "location": {
+        "city": "Pittsburgh",
+        "coordinates": {
+            "latitude": 40.4599756,
+            "longitude": -79.9308717
+        },
+        "country": "United States of America",
+        "timezone": "America/New_York",
+        "utcOffset": -4
     },
-    "utcOffset": -4,
-    "timezone": "America/New_York"
-  }
+    "moderators": [
+        {
+            "name": "Colin Dean",
+            "url": "https://twitter.com/colindean"
+        },
+        {
+            "name": "Justin Reese",
+            "url": "https://twitter.com/justinreese"
+        }
+    ],
+    "title": "GDCR2018 Pittsburgh",
+    "url": "https://www.meetup.com/Pittsburgh-Code-Supply/events/253736933/"
 }

--- a/_data/events_gdcr2018/Portland.json
+++ b/_data/events_gdcr2018/Portland.json
@@ -1,15 +1,20 @@
 {
-  "title": "PDX Global Day of Coderetreat 2018",
-  "url": "https://www.meetup.com/PDX-Software-Practice/events/254832597/",
-  "location": {
-    "utcOffset": -8,
-    "timezone": "America/Los_Angeles",
-    "city": "Portland",
-    "country": "United States of America",
-    "coordinates": {
-      "latitude": 45.518430,
-      "longitude": -122.680450
-    }
-  },
-  "moderators": ["@mplavcan"]
+    "location": {
+        "city": "Portland",
+        "coordinates": {
+            "latitude": 45.51843,
+            "longitude": -122.68045
+        },
+        "country": "United States of America",
+        "timezone": "America/Los_Angeles",
+        "utcOffset": -8
+    },
+    "moderators": [
+        {
+            "name": "Matt Plavcan",
+            "url": "https://twitter.com/mplavcan"
+        }
+    ],
+    "title": "PDX Global Day of Coderetreat 2018",
+    "url": "https://www.meetup.com/PDX-Software-Practice/events/254832597/"
 }

--- a/_data/events_gdcr2018/Portland_AgilePDX.json
+++ b/_data/events_gdcr2018/Portland_AgilePDX.json
@@ -1,19 +1,28 @@
 {
-  "title": "AgilePDX Woman-Focused Global Day of Coderetreat",
-  "url": "https://www.meetup.com/AgilePDX-User-Group-Portland-Metro/events/255280597/",
-  "moderators": [
-    "@morganpdx",
-    "@charlenesilver",
-    "@jeanatazuregate"
-  ],
-  "location": {
-    "city": "Portland",
-    "country": "United States of America",
-    "coordinates": {
-      "latitude": 45.5162534,
-      "longitude": -122.6770537
+    "location": {
+        "city": "Portland",
+        "coordinates": {
+            "latitude": 45.5162534,
+            "longitude": -122.6770537
+        },
+        "country": "United States of America",
+        "timezone": "America/Los_Angeles",
+        "utcOffset": -7
     },
-    "utcOffset": -7,
-    "timezone": "America/Los_Angeles"
-  }
+    "moderators": [
+        {
+            "name": "Morgan",
+            "url": "https://twitter.com/morganpdx"
+        },
+        {
+            "name": "Charlene Silveira",
+            "url": "https://twitter.com/charlenesilver"
+        },
+        {
+            "name": "Jean Richardson",
+            "url": "https://twitter.com/jeanatazuregate"
+        }
+    ],
+    "title": "AgilePDX Woman-Focused Global Day of Coderetreat",
+    "url": "https://www.meetup.com/AgilePDX-User-Group-Portland-Metro/events/255280597/"
 }

--- a/_data/events_gdcr2018/Poznan.json
+++ b/_data/events_gdcr2018/Poznan.json
@@ -1,17 +1,19 @@
 {
-  "title": "GDCR 2018 Poznań",
-  "url": "https://www.meetup.com/Poznan-Java-User-Group/events/255433496/",
-  "moderators": [
-    "Wojciech Buras"
-  ],
-  "location": {
-    "city": "Poznań",
-    "country": "Poland",
-    "coordinates": {
-      "latitude": 52.403597,
-      "longitude": 16.9136073
+    "location": {
+        "city": "Pozna\u0144",
+        "coordinates": {
+            "latitude": 52.403597,
+            "longitude": 16.9136073
+        },
+        "country": "Poland",
+        "timezone": "Europe/Warsaw",
+        "utcOffset": 2
     },
-    "utcOffset": 2,
-    "timezone": "Europe/Warsaw"
-  }
+    "moderators": [
+        {
+            "name": "Wojciech Buras"
+        }
+    ],
+    "title": "GDCR 2018 Pozna\u0144",
+    "url": "https://www.meetup.com/Poznan-Java-User-Group/events/255433496/"
 }

--- a/_data/events_gdcr2018/Prague.json
+++ b/_data/events_gdcr2018/Prague.json
@@ -1,18 +1,22 @@
 {
-  "title": "GDCR in Prague",
-  "url": "https://www.meetup.com/CodeRetreat-CZ/events/255966983/",
-  "moderators": [
-    "Jaroslav Holan",
-    "Dominik Mostek"
-  ],
-  "location": {
-    "city": "Prague",
-    "country": "Czech Republic",
-    "coordinates": {
-      "latitude": 50.0894207,
-      "longitude": 14.339685
+    "location": {
+        "city": "Prague",
+        "coordinates": {
+            "latitude": 50.0894207,
+            "longitude": 14.339685
+        },
+        "country": "Czech Republic",
+        "timezone": "Europe/Prague",
+        "utcOffset": 2
     },
-    "utcOffset": 2,
-    "timezone": "Europe/Prague"
-  }
+    "moderators": [
+        {
+            "name": "Jaroslav Holan"
+        },
+        {
+            "name": "Dominik Mostek"
+        }
+    ],
+    "title": "GDCR in Prague",
+    "url": "https://www.meetup.com/CodeRetreat-CZ/events/255966983/"
 }

--- a/_data/events_gdcr2018/Pune-ExpertTalks.json
+++ b/_data/events_gdcr2018/Pune-ExpertTalks.json
@@ -1,21 +1,30 @@
 {
-  "title": "GDCR @ ExpertTalks, Pune",
-  "url": "https://www.meetup.com/expert-talks-Pune/events/255576116/",
-  "moderators": [
-    "@npagnihotri",
-    "@nickdawiz"
-  ],
-  "sponsors": [
-    "@EqualExperts"
-  ],
-  "location": {
-    "city": "Pune",
-    "country": "India",
-    "coordinates": {
-      "latitude": 18.544905,
-      "longitude": 73.909751
+    "location": {
+        "city": "Pune",
+        "coordinates": {
+            "latitude": 18.544905,
+            "longitude": 73.909751
+        },
+        "country": "India",
+        "timezone": "Asia/Kolkata",
+        "utcOffset": 5.5
     },
-    "utcOffset": 5.5,
-    "timezone": "Asia/Kolkata"
-  }
+    "moderators": [
+        {
+            "name": "Nandan Agnihotri",
+            "url": "https://twitter.com/npagnihotri"
+        },
+        {
+            "name": "\u0e20\u0e40\u043a\u0e23",
+            "url": "https://twitter.com/nickdawiz"
+        }
+    ],
+    "sponsors": [
+        {
+            "name": "Equal Experts",
+            "url": "https://twitter.com/EqualExperts"
+        }
+    ],
+    "title": "GDCR @ ExpertTalks, Pune",
+    "url": "https://www.meetup.com/expert-talks-Pune/events/255576116/"
 }

--- a/_data/events_gdcr2018/Pune-India-CDKGlobal.json
+++ b/_data/events_gdcr2018/Pune-India-CDKGlobal.json
@@ -1,20 +1,32 @@
 {
-  "title": "Coderetreat @ CDK Global (India) Pvt. Ltd. Pune",
-  "url": "https://sites.google.com/view/cdkpuneevents",
-  "moderators": [
-    "@patel_deepesh",
-    "@shrinivas23",
-    "@kgpingle",
-    "@vibzone"
-  ],
-  "location": {
-    "city": "Pune",
-    "country": "India",
-    "coordinates": {
-      "latitude": 18.556056,
-      "longitude": 73.892118
+    "location": {
+        "city": "Pune",
+        "coordinates": {
+            "latitude": 18.556056,
+            "longitude": 73.892118
+        },
+        "country": "India",
+        "timezone": "Asia/Kolkata",
+        "utcOffset": 5.5
     },
-    "utcOffset": 5.5,
-    "timezone": "Asia/Kolkata"
-  }
+    "moderators": [
+        {
+            "name": "Deepesh Patel",
+            "url": "https://twitter.com/patel_deepesh"
+        },
+        {
+            "name": "shrinivas23",
+            "url": "https://twitter.com/shrinivas23"
+        },
+        {
+            "name": "Kalpak G. Pingle",
+            "url": "https://twitter.com/kgpingle"
+        },
+        {
+            "name": "Vibhor",
+            "url": "https://twitter.com/vibzone"
+        }
+    ],
+    "title": "Coderetreat @ CDK Global (India) Pvt. Ltd. Pune",
+    "url": "https://sites.google.com/view/cdkpuneevents"
 }

--- a/_data/events_gdcr2018/Pune-Nelkinda.json
+++ b/_data/events_gdcr2018/Pune-Nelkinda.json
@@ -1,23 +1,37 @@
 {
-  "title": "GDCR18 Nelkinda / Caring Company / Espressif, Pune",
-  "url": "http://nelkinda.com/events/2018/11/17/Global-Day-of-Coderetreat/Nelkinda/Pune-Nelkinda",
-  "moderators": [
-    "@rkreddykonyala",
-    "@SiddheshNikude",
-    "@ShwetaSadawarte"
-  ],
-  "sponsors": [
-    "Caring Company",
-    "@nelkinda"
-  ],
-  "location": {
-    "city": "Pune",
-    "country": "India",
-    "coordinates": {
-      "latitude": 18.5534022,
-      "longitude": 73.7967793
+    "location": {
+        "city": "Pune",
+        "coordinates": {
+            "latitude": 18.5534022,
+            "longitude": 73.7967793
+        },
+        "country": "India",
+        "timezone": "Asia/Kolkata",
+        "utcOffset": 5.5
     },
-    "utcOffset": 5.5,
-    "timezone": "Asia/Kolkata"
-  }
+    "moderators": [
+        {
+            "name": "Rama Krishna",
+            "url": "https://twitter.com/rkreddykonyala"
+        },
+        {
+            "name": "Siddhesh Nikude",
+            "url": "https://twitter.com/SiddheshNikude"
+        },
+        {
+            "name": "Shweta Sadawarte",
+            "url": "https://twitter.com/ShwetaSadawarte"
+        }
+    ],
+    "sponsors": [
+        {
+            "name": "Caring Company"
+        },
+        {
+            "name": "Nelkinda",
+            "url": "https://twitter.com/nelkinda"
+        }
+    ],
+    "title": "GDCR18 Nelkinda / Caring Company / Espressif, Pune",
+    "url": "http://nelkinda.com/events/2018/11/17/Global-Day-of-Coderetreat/Nelkinda/Pune-Nelkinda"
 }

--- a/_data/events_gdcr2018/Pune-SimplyTech.json
+++ b/_data/events_gdcr2018/Pune-SimplyTech.json
@@ -1,25 +1,46 @@
 {
-  "title": "GDCR18 SimplyTech / Perennial Systems, Pune",
-  "url": "https://www.meetup.com/SimplyTech/events/255739000/",
-  "moderators": [
-    "@azharlaskar",
-    "@pankaj_chndnkr",
-    "@yash_bhs",
-    "@GreatDharmatma"
-  ],
-  "sponsors": [
-    "@nelkinda",
-    "@perennialsys",
-    "@simplytech_in"
-  ],
-  "location": {
-    "city": "Pune",
-    "country": "India",
-    "coordinates": {
-      "latitude": 18.483507,
-      "longitude": 73.8555663
+    "location": {
+        "city": "Pune",
+        "coordinates": {
+            "latitude": 18.483507,
+            "longitude": 73.8555663
+        },
+        "country": "India",
+        "timezone": "Asia/Kolkata",
+        "utcOffset": 5.5
     },
-    "utcOffset": 5.5,
-    "timezone": "Asia/Kolkata"
-  }
+    "moderators": [
+        {
+            "name": "Azhar Laskar",
+            "url": "https://twitter.com/azharlaskar"
+        },
+        {
+            "name": "Pankaj Chandankar",
+            "url": "https://twitter.com/pankaj_chndnkr"
+        },
+        {
+            "name": "Yash Shanker",
+            "url": "https://twitter.com/yash_bhs"
+        },
+        {
+            "name": "Ajitem Sahasrabuddhe",
+            "url": "https://twitter.com/GreatDharmatma"
+        }
+    ],
+    "sponsors": [
+        {
+            "name": "Nelkinda",
+            "url": "https://twitter.com/nelkinda"
+        },
+        {
+            "name": "@perennialsys",
+            "url": "https://twitter.com/perennialsys"
+        },
+        {
+            "name": "SimplyTech",
+            "url": "https://twitter.com/simplytech_in"
+        }
+    ],
+    "title": "GDCR18 SimplyTech / Perennial Systems, Pune",
+    "url": "https://www.meetup.com/SimplyTech/events/255739000/"
 }

--- a/_data/events_gdcr2018/Pune-TechnoWise.json
+++ b/_data/events_gdcr2018/Pune-TechnoWise.json
@@ -1,21 +1,28 @@
 {
-  "title": "GDCR18 TechnoWise Pune",
-  "url": "https://www.meetup.com/TechnoWise/events/252655936/",
-  "moderators": [
-    "Mayank Dhanawade",
-    "Rajashree Malvade"
-  ],
-  "sponsors": [
-    "@technogise"
-  ],
-  "location": {
-    "city": "Pune",
-    "country": "India",
-    "coordinates": {
-      "latitude": 18.568405,
-      "longitude": 73.909133
+    "location": {
+        "city": "Pune",
+        "coordinates": {
+            "latitude": 18.568405,
+            "longitude": 73.909133
+        },
+        "country": "India",
+        "timezone": "Asia/Kolkata",
+        "utcOffset": 5.5
     },
-    "utcOffset": 5.5,
-    "timezone": "Asia/Kolkata"
-  }
+    "moderators": [
+        {
+            "name": "Mayank Dhanawade"
+        },
+        {
+            "name": "Rajashree Malvade"
+        }
+    ],
+    "sponsors": [
+        {
+            "name": "Technogise",
+            "url": "https://twitter.com/technogise"
+        }
+    ],
+    "title": "GDCR18 TechnoWise Pune",
+    "url": "https://www.meetup.com/TechnoWise/events/252655936/"
 }

--- a/_data/events_gdcr2018/Pune-e-Zest.json
+++ b/_data/events_gdcr2018/Pune-e-Zest.json
@@ -1,22 +1,34 @@
 {
-  "title": "GDCR18 e-Zest, Pune",
-  "url": "https://www.e-zest.com/global-day-of-coderetreat2018",
-  "moderators": [
-    "@bharatikoot",
-    "@christianhujer"
-  ],
-  "sponsors": [
-    "@nelkinda",
-    "@ezest"
-  ],
-  "location": {
-    "city": "Pune",
-    "country": "India",
-    "coordinates": {
-      "latitude": 18.578799,
-      "longitude": 73.7378663
+    "location": {
+        "city": "Pune",
+        "coordinates": {
+            "latitude": 18.578799,
+            "longitude": 73.7378663
+        },
+        "country": "India",
+        "timezone": "Asia/Kolkata",
+        "utcOffset": 5.5
     },
-    "utcOffset": 5.5,
-    "timezone": "Asia/Kolkata"
-  }
+    "moderators": [
+        {
+            "name": "Bharati Bastade Koot",
+            "url": "https://twitter.com/bharatikoot"
+        },
+        {
+            "name": "Christian Hujer",
+            "url": "https://twitter.com/christianhujer"
+        }
+    ],
+    "sponsors": [
+        {
+            "name": "Nelkinda",
+            "url": "https://twitter.com/nelkinda"
+        },
+        {
+            "name": "e-Zest Solutions",
+            "url": "https://twitter.com/ezest"
+        }
+    ],
+    "title": "GDCR18 e-Zest, Pune",
+    "url": "https://www.e-zest.com/global-day-of-coderetreat2018"
 }

--- a/_data/events_gdcr2018/Qaraghandy.json
+++ b/_data/events_gdcr2018/Qaraghandy.json
@@ -1,20 +1,26 @@
 {
-  "title": "GDCR18 in Qaraghandy",
-  "url": "https://events.epam.com/events/global-day-of-coderetreat-1",
-  "moderators": [
-    "@andrey_kovalski"
-  ],
-  "sponsors": [
-    "@EPAMKazakhstan"
-  ],
-  "location": {
-    "city": "Qaraghandy",
-    "country": "Kazakhstan",
-    "coordinates": {
-      "latitude": 49.823898,
-      "longitude": 73.0288879
+    "location": {
+        "city": "Qaraghandy",
+        "coordinates": {
+            "latitude": 49.823898,
+            "longitude": 73.0288879
+        },
+        "country": "Kazakhstan",
+        "timezone": "Asia/Almaty",
+        "utcOffset": 6
     },
-    "utcOffset": 6,
-    "timezone": "Asia/Almaty"
-  }
+    "moderators": [
+        {
+            "name": "\u0410\u043d\u0434\u0440\u0435\u0439 \u041a\u043e\u0432\u0430\u043b\u044c\u0441\u043a\u0438\u0439",
+            "url": "https://twitter.com/andrey_kovalski"
+        }
+    ],
+    "sponsors": [
+        {
+            "name": "EPAM Kazakhstan",
+            "url": "https://twitter.com/EPAMKazakhstan"
+        }
+    ],
+    "title": "GDCR18 in Qaraghandy",
+    "url": "https://events.epam.com/events/global-day-of-coderetreat-1"
 }

--- a/_data/events_gdcr2018/Rennes.json
+++ b/_data/events_gdcr2018/Rennes.json
@@ -1,19 +1,28 @@
 {
-    "title": "GDCR 2018 in Rennes",
-    "url": "https://www.meetup.com/fr-FR/Software-Craftsmanship-Rennes/events/255823348/",
-    "moderators": [
-        "@gcollic",
-        "@y0anr",
-        "@gsalaun1"
-    ],
     "location": {
         "city": "Rennes",
-        "country": "France",
         "coordinates": {
             "latitude": 48.1261204,
             "longitude": -1.689017
         },
-        "utcOffset": 2,
-        "timezone": "Europe/Paris"
-    }
+        "country": "France",
+        "timezone": "Europe/Paris",
+        "utcOffset": 2
+    },
+    "moderators": [
+        {
+            "name": "Guillaume Collic \u21bb",
+            "url": "https://twitter.com/gcollic"
+        },
+        {
+            "name": "@y0anr",
+            "url": "https://twitter.com/y0anr"
+        },
+        {
+            "name": "Ga\u00ebl Sala\u00fcn",
+            "url": "https://twitter.com/gsalaun1"
+        }
+    ],
+    "title": "GDCR 2018 in Rennes",
+    "url": "https://www.meetup.com/fr-FR/Software-Craftsmanship-Rennes/events/255823348/"
 }

--- a/_data/events_gdcr2018/Resistencia.json
+++ b/_data/events_gdcr2018/Resistencia.json
@@ -1,18 +1,24 @@
 {
-  "title": "GDCR 18 in Resistencia",
-  "url": "https://gdcr18.eventbrite.com.ar",
-  "moderators": [
-    "@matiasmasca",
-    "@fernandezja"
-  ],
-  "location": {
-    "city": "Resistencia",
-    "country": "Argentina",
-    "coordinates": {
-      "latitude": -27.44021,
-      "longitude": -58.98674
+    "location": {
+        "city": "Resistencia",
+        "coordinates": {
+            "latitude": -27.44021,
+            "longitude": -58.98674
+        },
+        "country": "Argentina",
+        "timezone": "America/Buenos_Aires",
+        "utcOffset": -3
     },
-    "utcOffset": -3,
-    "timezone": "America/Buenos_Aires"
-  }
+    "moderators": [
+        {
+            "name": "Mat\u00edas Mascazzini",
+            "url": "https://twitter.com/matiasmasca"
+        },
+        {
+            "name": "Jose A. Fernandez",
+            "url": "https://twitter.com/fernandezja"
+        }
+    ],
+    "title": "GDCR 18 in Resistencia",
+    "url": "https://gdcr18.eventbrite.com.ar"
 }

--- a/_data/events_gdcr2018/Riga.json
+++ b/_data/events_gdcr2018/Riga.json
@@ -1,18 +1,24 @@
 {
-  "title": "Global Day of Coderetreat 2018",
-  "url": "https://www.meetup.com/Latvian-Developers-Network/events/253952435/",
-  "moderators": [
-    "@arkadi_t",
-    "@acankr"
-  ],
-  "location": {
-    "city": "Riga",
-    "country": "Latvia",
-    "coordinates": {
-      "latitude": 56.953709,
-      "longitude": 24.099244
+    "location": {
+        "city": "Riga",
+        "coordinates": {
+            "latitude": 56.953709,
+            "longitude": 24.099244
+        },
+        "country": "Latvia",
+        "timezone": "Europe/Riga",
+        "utcOffset": 3
     },
-    "utcOffset": 3,
-    "timezone": "Europe/Riga"
-  }
+    "moderators": [
+        {
+            "name": "Arkadi Shishlov",
+            "url": "https://twitter.com/arkadi_t"
+        },
+        {
+            "name": "Antons Kranga",
+            "url": "https://twitter.com/acankr"
+        }
+    ],
+    "title": "Global Day of Coderetreat 2018",
+    "url": "https://www.meetup.com/Latvian-Developers-Network/events/253952435/"
 }

--- a/_data/events_gdcr2018/Rochester.json
+++ b/_data/events_gdcr2018/Rochester.json
@@ -1,20 +1,26 @@
 {
-  "title": "GDCR18 in Rochester",
-  "url": "https://www.meetup.com/RocDev/events/253288924/",
-  "moderators": [
-    "@geowa4"
-  ],
-  "sponsors": [
-    "@paychex"
-  ],
-  "location": {
-    "city": "Rochester",
-    "country": "United States of America",
-    "coordinates": {
-      "latitude": 43.2258726,
-      "longitude": -77.3911697
+    "location": {
+        "city": "Rochester",
+        "coordinates": {
+            "latitude": 43.2258726,
+            "longitude": -77.3911697
+        },
+        "country": "United States of America",
+        "timezone": "America/New_York",
+        "utcOffset": -4
     },
-    "utcOffset": -4,
-    "timezone": "America/New_York"
-  }
+    "moderators": [
+        {
+            "name": "george iv",
+            "url": "https://twitter.com/geowa4"
+        }
+    ],
+    "sponsors": [
+        {
+            "name": "Paychex",
+            "url": "https://twitter.com/paychex"
+        }
+    ],
+    "title": "GDCR18 in Rochester",
+    "url": "https://www.meetup.com/RocDev/events/253288924/"
 }

--- a/_data/events_gdcr2018/Rzeszow.json
+++ b/_data/events_gdcr2018/Rzeszow.json
@@ -1,21 +1,28 @@
 {
-  "title": "Global Day of Coderetreat - Rzeszow 2018",
-  "url": "https://softwaretalks.pl/wydarzenia/global-day-coderetreat-4/",
-  "moderators": [
-    "Mateusz Dronka",
-    "Sylwester Zimon"
-  ],
-  "sponsors": [
-    "@pgssoftware"
-  ],
-  "location": {
-    "city": "Rzeszow",
-    "country": "Poland",
-    "coordinates": {
-      "latitude": 50.0492628,
-      "longitude": 22.006778
+    "location": {
+        "city": "Rzeszow",
+        "coordinates": {
+            "latitude": 50.0492628,
+            "longitude": 22.006778
+        },
+        "country": "Poland",
+        "timezone": "Europe/Warsaw",
+        "utcOffset": 2
     },
-    "utcOffset": 2,
-    "timezone": "Europe/Warsaw"
-  }
+    "moderators": [
+        {
+            "name": "Mateusz Dronka"
+        },
+        {
+            "name": "Sylwester Zimon"
+        }
+    ],
+    "sponsors": [
+        {
+            "name": "PGS Software",
+            "url": "https://twitter.com/pgssoftware"
+        }
+    ],
+    "title": "Global Day of Coderetreat - Rzeszow 2018",
+    "url": "https://softwaretalks.pl/wydarzenia/global-day-coderetreat-4/"
 }

--- a/_data/events_gdcr2018/SaltLakeCity.json
+++ b/_data/events_gdcr2018/SaltLakeCity.json
@@ -1,18 +1,24 @@
 {
-  "title": "Global Day of Coderetreat 2018 - Salt Lake City",
-  "url": "https://www.eventbrite.com/e/global-day-of-coderetreat-slc-ut-usa-tickets-51425405773",
-  "moderators": [
-    "Neil Sorensen",
-    "Jon Turner",
-    "Dave Adsit"
-  ],
-  "location": {
-    "city": "Salt Lake City",
-    "country": "United States of America",
-    "coordinates": {
-      "latitude": 40.5643055,
-      "longitude": -111.9037559
+    "location": {
+        "city": "Salt Lake City",
+        "coordinates": {
+            "latitude": 40.5643055,
+            "longitude": -111.9037559
+        },
+        "country": "United States of America",
+        "timezone": "America/Boise"
     },
-    "timezone": "America/Boise"
-  }
+    "moderators": [
+        {
+            "name": "Neil Sorensen"
+        },
+        {
+            "name": "Jon Turner"
+        },
+        {
+            "name": "Dave Adsit"
+        }
+    ],
+    "title": "Global Day of Coderetreat 2018 - Salt Lake City",
+    "url": "https://www.eventbrite.com/e/global-day-of-coderetreat-slc-ut-usa-tickets-51425405773"
 }

--- a/_data/events_gdcr2018/SanMateo-punchh.json
+++ b/_data/events_gdcr2018/SanMateo-punchh.json
@@ -1,18 +1,22 @@
 {
-  "title": "Global Day of Code Retreat 2018 - Punchh San Mateo",
-  "url": "https://www.meetup.com/Punchh-Tech/events/255098080/",
-  "moderators": [
-    "Andrew McElroy",
-    "Geri Markey"
-  ],
-  "location": {
-    "city": "San Mateo",
-    "country": "United States of America",
-    "coordinates": {
-      "latitude": 37.553475,
-      "longitude": -122.300244
+    "location": {
+        "city": "San Mateo",
+        "coordinates": {
+            "latitude": 37.553475,
+            "longitude": -122.300244
+        },
+        "country": "United States of America",
+        "timezone": "America/Los_Angeles",
+        "utcOffset": -7
     },
-    "utcOffset": -7,
-    "timezone": "America/Los_Angeles"
-  }
+    "moderators": [
+        {
+            "name": "Andrew McElroy"
+        },
+        {
+            "name": "Geri Markey"
+        }
+    ],
+    "title": "Global Day of Code Retreat 2018 - Punchh San Mateo",
+    "url": "https://www.meetup.com/Punchh-Tech/events/255098080/"
 }

--- a/_data/events_gdcr2018/Seattle-codecrafters.json
+++ b/_data/events_gdcr2018/Seattle-codecrafters.json
@@ -1,18 +1,24 @@
 {
-  "title": "GDCR 2018 - Seattle Code Crafters",
-  "url": "https://www.meetup.com/seattle-software-craftsmanship/events/254972860/",
-  "moderators": [
-    "@katanation",
-    "@paigeisxp"
-  ],
-  "location": {
-    "city": "Lynnwood",
-    "country": "United States of America",
-    "coordinates": {
-      "latitude": 47.845791,
-      "longitude": -122.293084
+    "location": {
+        "city": "Lynnwood",
+        "coordinates": {
+            "latitude": 47.845791,
+            "longitude": -122.293084
+        },
+        "country": "United States of America",
+        "timezone": "America/Los_Angeles",
+        "utcOffset": -7
     },
-    "utcOffset": -7,
-    "timezone": "America/Los_Angeles"
-  }
+    "moderators": [
+        {
+            "name": "Steve Kuo",
+            "url": "https://twitter.com/katanation"
+        },
+        {
+            "name": "Paige Watson",
+            "url": "https://twitter.com/paigeisxp"
+        }
+    ],
+    "title": "GDCR 2018 - Seattle Code Crafters",
+    "url": "https://www.meetup.com/seattle-software-craftsmanship/events/254972860/"
 }

--- a/_data/events_gdcr2018/Shanghai.json
+++ b/_data/events_gdcr2018/Shanghai.json
@@ -1,21 +1,27 @@
 {
-    "title": "GDCR 2018 in Shanghai",
-    "url": "https://jinshuju.net/f/qL5Ol6",
-    "moderators": [
-        "Wu Ke",
-        "Zhang Yaguang"
-    ],
-    "sponsors": [
-        "SAP"
-    ],
     "location": {
         "city": "Shanghai",
-        "country": "China",
         "coordinates": {
             "latitude": 31.2019621,
             "longitude": 121.6006583
         },
-        "utcOffset": 8,
-        "timezone": "Asia/Shanghai"
-    }
+        "country": "China",
+        "timezone": "Asia/Shanghai",
+        "utcOffset": 8
+    },
+    "moderators": [
+        {
+            "name": "Wu Ke"
+        },
+        {
+            "name": "Zhang Yaguang"
+        }
+    ],
+    "sponsors": [
+        {
+            "name": "SAP"
+        }
+    ],
+    "title": "GDCR 2018 in Shanghai",
+    "url": "https://jinshuju.net/f/qL5Ol6"
 }

--- a/_data/events_gdcr2018/SophiaAntipolis.json
+++ b/_data/events_gdcr2018/SophiaAntipolis.json
@@ -1,17 +1,20 @@
 {
-  "title": "GDCR18 in Sophia Antipolis",
-  "url": "https://goo.gl/forms/E4lqSPYE9M9Ctp3u2",
-  "moderators": [
-    "@Bureau_du_Code"
-  ],
-  "location": {
-    "city": "Sophia Antipolis",
-    "country": "France",
-    "coordinates": {
-      "latitude": 43.6166482,
-      "longitude": 7.0357542
+    "location": {
+        "city": "Sophia Antipolis",
+        "coordinates": {
+            "latitude": 43.6166482,
+            "longitude": 7.0357542
+        },
+        "country": "France",
+        "timezone": "Europe/Monaco",
+        "utcOffset": 2
     },
-    "utcOffset": 2,
-    "timezone": "Europe/Monaco"
-  }
+    "moderators": [
+        {
+            "name": "Bureau du Code",
+            "url": "https://twitter.com/Bureau_du_Code"
+        }
+    ],
+    "title": "GDCR18 in Sophia Antipolis",
+    "url": "https://goo.gl/forms/E4lqSPYE9M9Ctp3u2"
 }

--- a/_data/events_gdcr2018/Sydney.json
+++ b/_data/events_gdcr2018/Sydney.json
@@ -1,20 +1,28 @@
 {
-  "title": "Sydney Global Day of Code Retreat 2018",
-  "url": "https://www.eventbrite.com.au/e/sydney-global-day-of-code-retreat-2018-tickets-51246992133",
-  "moderators": [
-    "Thomas Eizinger",
-    "Lloyd Fournier",
-    "Philipp Hoenisch",
-    "Franck Royer"
-  ],
-  "location": {
-    "city": "Sydney",
-    "country": "Australia",
-    "coordinates": {
-      "latitude": -33.8679919,
-      "longitude": 151.2049818
+    "location": {
+        "city": "Sydney",
+        "coordinates": {
+            "latitude": -33.8679919,
+            "longitude": 151.2049818
+        },
+        "country": "Australia",
+        "timezone": "Australia/Sydney",
+        "utcOffset": 10
     },
-    "utcOffset": 10,
-    "timezone": "Australia/Sydney"
-  }
+    "moderators": [
+        {
+            "name": "Thomas Eizinger"
+        },
+        {
+            "name": "Lloyd Fournier"
+        },
+        {
+            "name": "Philipp Hoenisch"
+        },
+        {
+            "name": "Franck Royer"
+        }
+    ],
+    "title": "Sydney Global Day of Code Retreat 2018",
+    "url": "https://www.eventbrite.com.au/e/sydney-global-day-of-code-retreat-2018-tickets-51246992133"
 }

--- a/_data/events_gdcr2018/TEMPLATE
+++ b/_data/events_gdcr2018/TEMPLATE
@@ -1,23 +1,38 @@
 {
-  "title": "GDCR17 Softwerkskammer Berlin",
-  "url": "https://www.eventbrite.com/e/global-day-of-coderetreat-2017-softwerkskammer-berlin-tickets-39627587180",
-  "moderators": [
-    "@alastairs",
-    "@martinklose",
-    "@mrksdck"
-  ],
-  "sponsors": [
-    "@GoEuro",
-    "@Wikimedia"
-  ],
-  "location": {
-    "city": "Berlin",
-    "country": "Germany",
-    "coordinates": {
-      "latitude": 52.5193449,
-      "longitude": 13.4003222
+    "location": {
+        "city": "Berlin",
+        "coordinates": {
+            "latitude": 52.5193449,
+            "longitude": 13.4003222
+        },
+        "country": "Germany",
+        "timezone": "Europe/Berlin",
+        "utcOffset": 1
     },
-    "utcOffset": 1,
-    "timezone": "Europe/Berlin"
-  }
+    "moderators": [
+        {
+            "name": "Alastair Smith",
+            "url": "https://twitter.com/alastairs"
+        },
+        {
+            "name": "Martin Klose",
+            "url": "https://twitter.com/martinklose"
+        },
+        {
+            "name": "Markus Decke",
+            "url": "https://twitter.com/mrksdck"
+        }
+    ],
+    "sponsors": [
+        {
+            "name": "@GoEuro",
+            "url": "https://twitter.com/GoEuro"
+        },
+        {
+            "name": "Wikimedia",
+            "url": "https://twitter.com/Wikimedia"
+        }
+    ],
+    "title": "GDCR17 Softwerkskammer Berlin",
+    "url": "https://www.eventbrite.com/e/global-day-of-coderetreat-2017-softwerkskammer-berlin-tickets-39627587180"
 }

--- a/_data/events_gdcr2018/TelAviv.json
+++ b/_data/events_gdcr2018/TelAviv.json
@@ -1,17 +1,19 @@
 {
-  "title": "GDCR@TelAviv",
-"url": "https://www.eventbrite.com/e/code-retreat-wwwcoderetreatorg-day-israel-tickets-47661647270",
-  "moderators": [
- 
-    "@Yaki_Koren"
-  ],
-  "location": {
-    "city": "Tel Aviv",
-    "country": "Israel",
-    "coordinates": {
-      "latitude": 32.109333,
-      "longitude": 34.855499
+    "location": {
+        "city": "Tel Aviv",
+        "coordinates": {
+            "latitude": 32.109333,
+            "longitude": 34.855499
+        },
+        "country": "Israel",
+        "utcOffset": 2
     },
-    "utcOffset": 2
-  }
+    "moderators": [
+        {
+            "name": "yaki koren",
+            "url": "https://twitter.com/Yaki_Koren"
+        }
+    ],
+    "title": "GDCR@TelAviv",
+    "url": "https://www.eventbrite.com/e/code-retreat-wwwcoderetreatorg-day-israel-tickets-47661647270"
 }

--- a/_data/events_gdcr2018/Thessaloniki.json
+++ b/_data/events_gdcr2018/Thessaloniki.json
@@ -1,17 +1,20 @@
 {
-  "title": "GDCR in Thessaloniki",
-  "url": "http://coderetreat.gr",
-  "moderators": [
-    "@softwaregarden"
-  ],
-  "location": {
-    "city": "Thessaloniki",
-    "country": "Greece",
-    "coordinates": {
-      "latitude": 40.6211912,
-      "longitude": 22.9284748
+    "location": {
+        "city": "Thessaloniki",
+        "coordinates": {
+            "latitude": 40.6211912,
+            "longitude": 22.9284748
+        },
+        "country": "Greece",
+        "timezone": "Europe/Athens",
+        "utcOffset": 3
     },
-    "utcOffset": 3,
-    "timezone": "Europe/Athens"
-  }
+    "moderators": [
+        {
+            "name": "Software Gardener",
+            "url": "https://twitter.com/softwaregarden"
+        }
+    ],
+    "title": "GDCR in Thessaloniki",
+    "url": "http://coderetreat.gr"
 }

--- a/_data/events_gdcr2018/Toulouse.json
+++ b/_data/events_gdcr2018/Toulouse.json
@@ -1,15 +1,24 @@
 {
-  "title": "GDCR in Toulouse",
-  "url": "https://www.meetup.com/Software-Crafters-Toulouse/events/254955655/",
-  "moderators": ["@ludopradel", "@jeanpalaz "],
-  "location": {
-    "city": "Toulouse",
-    "country": "France",
-    "coordinates": {
-      "latitude": 43.60563,
-      "longitude": 1.44573
+    "location": {
+        "city": "Toulouse",
+        "coordinates": {
+            "latitude": 43.60563,
+            "longitude": 1.44573
+        },
+        "country": "France",
+        "timezone": "Europe/Paris",
+        "utcOffset": 2
     },
-    "utcOffset": 2,
-    "timezone": "Europe/Paris"
-  }
+    "moderators": [
+        {
+            "name": "Ludo Pradel",
+            "url": "https://twitter.com/ludopradel"
+        },
+        {
+            "name": "Jean PALAZUELOS",
+            "url": "https://twitter.com/jeanpalaz "
+        }
+    ],
+    "title": "GDCR in Toulouse",
+    "url": "https://www.meetup.com/Software-Crafters-Toulouse/events/254955655/"
 }

--- a/_data/events_gdcr2018/Turku.json
+++ b/_data/events_gdcr2018/Turku.json
@@ -1,21 +1,38 @@
 {
-  "title": "GDCR Turku",
-  "url": "https://www.eventbrite.com/e/global-day-of-coderetreat-turku-tickets-51543670506",
-  "moderators": [
-    "@tee_mu",
-    "@mikaelkulma",
-    "@tanjalankiaj",
-    "@jonraem"
-  ],
-  "location": {
-    "city": "Turku",
-    "country": "Finland",
-    "coordinates": {
-      "latitude": 60.4495844,
-      "longitude": 22.2665197
+    "location": {
+        "city": "Turku",
+        "coordinates": {
+            "latitude": 60.4495844,
+            "longitude": 22.2665197
+        },
+        "country": "Finland",
+        "timezone": "Europe/Helsinki",
+        "utcOffset": 3
     },
-    "utcOffset": 3,
-    "timezone": "Europe/Helsinki"
-  },
-  "sponsors": ["@houstoninc"]
+    "moderators": [
+        {
+            "name": "Teemu M\u00e4ntyharju",
+            "url": "https://twitter.com/tee_mu"
+        },
+        {
+            "name": "Mikael Kulma",
+            "url": "https://twitter.com/mikaelkulma"
+        },
+        {
+            "name": "@tanjalankiaj",
+            "url": "https://twitter.com/tanjalankiaj"
+        },
+        {
+            "name": "Joni R\u00e4m\u00f6",
+            "url": "https://twitter.com/jonraem"
+        }
+    ],
+    "sponsors": [
+        {
+            "name": "Houston Inc",
+            "url": "https://twitter.com/houstoninc"
+        }
+    ],
+    "title": "GDCR Turku",
+    "url": "https://www.eventbrite.com/e/global-day-of-coderetreat-turku-tickets-51543670506"
 }

--- a/_data/events_gdcr2018/Utrecht.json
+++ b/_data/events_gdcr2018/Utrecht.json
@@ -1,22 +1,33 @@
 {
-  "title": "Global Day of Code Retreat - Utrecht 2018",
-  "url": "https://www.meetup.com/Utrecht-Java-User-Group/events/248206538/",
-  "moderators": [
-    "@ThodorisBais",
-    "Joost Baas",
-    "@abannany"
-  ],
-  "sponsors": [
-   "@CodeSquadNL"
-  ],
-  "location": {
-    "city": "Utrecht",
-    "country": "Netherlands",
-    "coordinates": {
-      "latitude": 52.0907,
-      "longitude": 5.1214
+    "location": {
+        "city": "Utrecht",
+        "coordinates": {
+            "latitude": 52.0907,
+            "longitude": 5.1214
+        },
+        "country": "Netherlands",
+        "timezone": "Europe/Amsterdam",
+        "utcOffset": 2
     },
-    "utcOffset": 2,
-    "timezone": "Europe/Amsterdam"
-  }
+    "moderators": [
+        {
+            "name": "Thodoris Bais",
+            "url": "https://twitter.com/ThodorisBais"
+        },
+        {
+            "name": "Joost Baas"
+        },
+        {
+            "name": "abannany",
+            "url": "https://twitter.com/abannany"
+        }
+    ],
+    "sponsors": [
+        {
+            "name": "CodeSquad",
+            "url": "https://twitter.com/CodeSquadNL"
+        }
+    ],
+    "title": "Global Day of Code Retreat - Utrecht 2018",
+    "url": "https://www.meetup.com/Utrecht-Java-User-Group/events/248206538/"
 }

--- a/_data/events_gdcr2018/Valencia.json
+++ b/_data/events_gdcr2018/Valencia.json
@@ -1,20 +1,26 @@
 {
-  "title": "Global Day of Coderetreat 2018 in Valencia",
-  "url": "https://www.meetup.com/es-ES/Aprende-a-programar-en-Valencia/events/255737180",
-  "moderators": [
-    "@devscola"
-  ],
-  "sponsors": [
-    "@FlywireEng"
-  ],
-  "location": {
-    "city": "Valencia",
-    "country": "Spain",
-    "coordinates": {
-      "latitude": 39.4708326,
-      "longitude": -0.3674851
+    "location": {
+        "city": "Valencia",
+        "coordinates": {
+            "latitude": 39.4708326,
+            "longitude": -0.3674851
+        },
+        "country": "Spain",
+        "timezone": "Europe/Madrid",
+        "utcOffset": 2
     },
-    "utcOffset": 2,
-    "timezone": "Europe/Madrid"
-  }
+    "moderators": [
+        {
+            "name": "devscola",
+            "url": "https://twitter.com/devscola"
+        }
+    ],
+    "sponsors": [
+        {
+            "name": "Flywire Engineering",
+            "url": "https://twitter.com/FlywireEng"
+        }
+    ],
+    "title": "Global Day of Coderetreat 2018 in Valencia",
+    "url": "https://www.meetup.com/es-ES/Aprende-a-programar-en-Valencia/events/255737180"
 }

--- a/_data/events_gdcr2018/Vechta.json
+++ b/_data/events_gdcr2018/Vechta.json
@@ -1,17 +1,20 @@
 {
-  "title": "GDCR18 in Vechta",
-  "url": "https://www.xing.com/events/global-day-of-code-retreat-1991164",
-  "moderators": [
-    "@StefanMacke"
-  ],
-  "location": {
-    "city": "Vechta",
-    "country": "Germany",
-    "coordinates": {
-      "latitude": 52.72132,
-      "longitude": 8.2767212
+    "location": {
+        "city": "Vechta",
+        "coordinates": {
+            "latitude": 52.72132,
+            "longitude": 8.2767212
+        },
+        "country": "Germany",
+        "timezone": "Europe/Berlin",
+        "utcOffset": 1
     },
-    "utcOffset": 1,
-    "timezone": "Europe/Berlin"
-  }
+    "moderators": [
+        {
+            "name": "Stefan Macke",
+            "url": "https://twitter.com/StefanMacke"
+        }
+    ],
+    "title": "GDCR18 in Vechta",
+    "url": "https://www.xing.com/events/global-day-of-code-retreat-1991164"
 }

--- a/_data/events_gdcr2018/Vienna.json
+++ b/_data/events_gdcr2018/Vienna.json
@@ -1,21 +1,30 @@
 {
-  "title": "GDCR18 in Vienna, Austria",
-  "url": "https://techtalk.at/trainings/global-day-of-coderetreat-2018/",
-  "moderators": [
-    "@jbrains",
-    "@codecopkofler"
-  ],
-  "sponsors": [
-    "@techtalks"
-  ],
-  "location": {
-    "city": "Vienna",
-    "country": "Austria",
-    "coordinates": {
-      "latitude": 48.23645,
-      "longitude": 16.413294
+    "location": {
+        "city": "Vienna",
+        "coordinates": {
+            "latitude": 48.23645,
+            "longitude": 16.413294
+        },
+        "country": "Austria",
+        "timezone": "Europe/Vienna",
+        "utcOffset": 2
     },
-    "utcOffset": 2,
-    "timezone": "Europe/Vienna"
-  }
+    "moderators": [
+        {
+            "name": "\u2615 J. B. Rainsberger",
+            "url": "https://twitter.com/jbrains"
+        },
+        {
+            "name": "Peter Kofler",
+            "url": "https://twitter.com/codecopkofler"
+        }
+    ],
+    "sponsors": [
+        {
+            "name": "TechTalk",
+            "url": "https://twitter.com/techtalks"
+        }
+    ],
+    "title": "GDCR18 in Vienna, Austria",
+    "url": "https://techtalk.at/trainings/global-day-of-coderetreat-2018/"
 }

--- a/_data/events_gdcr2018/Vilnius.json
+++ b/_data/events_gdcr2018/Vilnius.json
@@ -1,17 +1,20 @@
 {
-    "title": "GDCR18 in Vilnius",
-    "url": "https://gdcr-vilnius-2018.eventbrite.com",
-    "moderators": [
-      "@ogrigas"
-    ],
     "location": {
-      "city": "Vilnius",
-      "country": "Lithuania",
-      "coordinates": {
-        "latitude": 54.701825,
-        "longitude": 25.2630313
-      },
-      "utcOffset": 3,
-      "timezone": "Europe/Vilnius"
-    }
-  }
+        "city": "Vilnius",
+        "coordinates": {
+            "latitude": 54.701825,
+            "longitude": 25.2630313
+        },
+        "country": "Lithuania",
+        "timezone": "Europe/Vilnius",
+        "utcOffset": 3
+    },
+    "moderators": [
+        {
+            "name": "Osvaldas Grigas",
+            "url": "https://twitter.com/ogrigas"
+        }
+    ],
+    "title": "GDCR18 in Vilnius",
+    "url": "https://gdcr-vilnius-2018.eventbrite.com"
+}

--- a/_data/events_gdcr2018/Warsaw.json
+++ b/_data/events_gdcr2018/Warsaw.json
@@ -1,18 +1,24 @@
 {
-  "title": "Code Retreat at Codility",
-  "url": "https://www.meetup.com/Codility-and-Friends/events/255736594/",
-  "moderators": [
-    "@erbetowski",
-    "@83TB"
-  ],
-  "location": {
-    "city": "Warsaw",
-    "country": "Poland",
-    "coordinates": {
-      "latitude": 52.2426982,
-      "longitude": 21.0220026
+    "location": {
+        "city": "Warsaw",
+        "coordinates": {
+            "latitude": 52.2426982,
+            "longitude": 21.0220026
+        },
+        "country": "Poland",
+        "timezone": "Europe/Warsaw",
+        "utcOffset": 2
     },
-    "utcOffset": 2,
-    "timezone": "Europe/Warsaw"
-  }
+    "moderators": [
+        {
+            "name": "Wojtek Erbetowski",
+            "url": "https://twitter.com/erbetowski"
+        },
+        {
+            "name": "Kuba Kucharski",
+            "url": "https://twitter.com/83TB"
+        }
+    ],
+    "title": "Code Retreat at Codility",
+    "url": "https://www.meetup.com/Codility-and-Friends/events/255736594/"
 }

--- a/_data/events_gdcr2018/WestlakeVillage.json
+++ b/_data/events_gdcr2018/WestlakeVillage.json
@@ -1,21 +1,28 @@
 {
-  "title": "GDCR 2018 in Westlake Village",
-  "url": "https://www.meetup.com/codecraftgroup/events/254073682/",
-  "moderators": [
-    "Jamie Isaacs",
-    "Chandler Giusti"
-  ],
-    "sponsors": [
-    "@cj_engineering"
-  ],
-  "location": {
-    "city": "Westlake Village, CA",
-    "country": "United States of America",
-    "coordinates": {
-      "latitude": 34.1511938,
-      "longitude": -118.7952308
+    "location": {
+        "city": "Westlake Village, CA",
+        "coordinates": {
+            "latitude": 34.1511938,
+            "longitude": -118.7952308
+        },
+        "country": "United States of America",
+        "timezone": "America/Los_Angeles",
+        "utcOffset": -7
     },
-    "utcOffset": -7,
-    "timezone": "America/Los_Angeles"
-  }
+    "moderators": [
+        {
+            "name": "Jamie Isaacs"
+        },
+        {
+            "name": "Chandler Giusti"
+        }
+    ],
+    "sponsors": [
+        {
+            "name": "CJ Engineering",
+            "url": "https://twitter.com/cj_engineering"
+        }
+    ],
+    "title": "GDCR 2018 in Westlake Village",
+    "url": "https://www.meetup.com/codecraftgroup/events/254073682/"
 }

--- a/_data/events_gdcr2018/Winnipeg.json
+++ b/_data/events_gdcr2018/Winnipeg.json
@@ -1,17 +1,20 @@
 {
-  "title": "GDCR18 Winnipeg",
-  "url": "https://www.eventbrite.com/e/gdcr18-winnipeg-tickets-51674255088",
-  "moderators": [
-    "@davidalpert"
-  ],
-  "location": {
-    "city": "Winnipeg",
-    "country": "Canada",
-    "coordinates": {
-      "latitude": 49.8953855,
-      "longitude": -97.1381449
+    "location": {
+        "city": "Winnipeg",
+        "coordinates": {
+            "latitude": 49.8953855,
+            "longitude": -97.1381449
+        },
+        "country": "Canada",
+        "timezone": "America/Winnipeg",
+        "utcOffset": -5
     },
-    "utcOffset": -5,
-    "timezone": "America/Winnipeg"
-  }
+    "moderators": [
+        {
+            "name": "David Alpert",
+            "url": "https://twitter.com/davidalpert"
+        }
+    ],
+    "title": "GDCR18 Winnipeg",
+    "url": "https://www.eventbrite.com/e/gdcr18-winnipeg-tickets-51674255088"
 }

--- a/_data/events_gdcr2018/Wroclaw.json
+++ b/_data/events_gdcr2018/Wroclaw.json
@@ -1,17 +1,20 @@
 {
-  "title": "Global Day of Coderetreat - Wroclaw 2018",
-  "url": "https://softwaretalks.pl/wydarzenia/global-day-coderetreat-2/",
-  "moderators": [
-    "@b_rodak"
-  ],
-  "location": {
-    "city": "Wroclaw",
-    "country": "Poland",
-    "coordinates": {
-      "latitude": 51.0964064,
-      "longitude": 17.0327242
+    "location": {
+        "city": "Wroclaw",
+        "coordinates": {
+            "latitude": 51.0964064,
+            "longitude": 17.0327242
+        },
+        "country": "Poland",
+        "timezone": "Europe/Warsaw",
+        "utcOffset": 2
     },
-    "utcOffset": 2,
-    "timezone": "Europe/Warsaw"
-  }
+    "moderators": [
+        {
+            "name": "Bart\u0142omiej Rodak",
+            "url": "https://twitter.com/b_rodak"
+        }
+    ],
+    "title": "Global Day of Coderetreat - Wroclaw 2018",
+    "url": "https://softwaretalks.pl/wydarzenia/global-day-coderetreat-2/"
 }

--- a/_data/events_gdcr2018/Zaragoza.json
+++ b/_data/events_gdcr2018/Zaragoza.json
@@ -1,15 +1,20 @@
 {
-    "title": "GDCR18 en Zaragoza",
-    "url": "https://www.meetup.com/es-ES/agilearagon/events/244698186/",
-    "moderators": ["@nimpedrojo"],
     "location": {
-      "city": "Zaragoza",
-      "country": "Spain",
-      "coordinates": {
-        "latitude": 41.6516859,
-        "longitude": -0.9300004
-      },
-      "utcOffset": 2,
-      "timezone": "Europe/Madrid"
-    }
-  }
+        "city": "Zaragoza",
+        "coordinates": {
+            "latitude": 41.6516859,
+            "longitude": -0.9300004
+        },
+        "country": "Spain",
+        "timezone": "Europe/Madrid",
+        "utcOffset": 2
+    },
+    "moderators": [
+        {
+            "name": "Pedro Lafuente",
+            "url": "https://twitter.com/nimpedrojo"
+        }
+    ],
+    "title": "GDCR18 en Zaragoza",
+    "url": "https://www.meetup.com/es-ES/agilearagon/events/244698186/"
+}

--- a/_data/events_gdcr2018/Zielona-Gora.json
+++ b/_data/events_gdcr2018/Zielona-Gora.json
@@ -1,17 +1,19 @@
 {
-  "title": "GDCR 2018 in Zielona Gora",
-  "url": "https://docs.google.com/forms/d/e/1FAIpQLSdYYwBQOrVEPrvFYrfdJKzxqZgGhy006LlNJueqkA1x1amDEg/viewform",
-  "moderators": [
-    "Anna Meisinger"
-  ],
-  "location": {
-    "city": "Zielona Gora",
-    "country": "Poland",
-    "coordinates": {
-      "latitude": 51.942083,
-      "longitude": 15.5279537
+    "location": {
+        "city": "Zielona Gora",
+        "coordinates": {
+            "latitude": 51.942083,
+            "longitude": 15.5279537
+        },
+        "country": "Poland",
+        "timezone": "Europe/Warsaw",
+        "utcOffset": 2
     },
-    "utcOffset": 2,
-    "timezone": "Europe/Warsaw"
-  }
+    "moderators": [
+        {
+            "name": "Anna Meisinger"
+        }
+    ],
+    "title": "GDCR 2018 in Zielona Gora",
+    "url": "https://docs.google.com/forms/d/e/1FAIpQLSdYYwBQOrVEPrvFYrfdJKzxqZgGhy006LlNJueqkA1x1amDEg/viewform"
 }

--- a/_data/events_gdcr2018/Zurich.json
+++ b/_data/events_gdcr2018/Zurich.json
@@ -1,17 +1,20 @@
 {
-  "title": "GDCR18 in Zurich",
-  "url": "https://zurich.codersonly.org/events/code-retreat",
-  "moderators": [
-    "@infinitary"
-  ],
-  "location": {
-    "city": "Zurich",
-    "country": "Switzerland",
-    "coordinates": {
-      "latitude": 47.36466,
-      "longitude": 8.53092
+    "location": {
+        "city": "Zurich",
+        "coordinates": {
+            "latitude": 47.36466,
+            "longitude": 8.53092
+        },
+        "country": "Switzerland",
+        "timezone": "Europe/Zurich",
+        "utcOffset": 2
     },
-    "utcOffset": 2,
-    "timezone": "Europe/Zurich"
-  }
+    "moderators": [
+        {
+            "name": "i'm too meta for my shirt",
+            "url": "https://twitter.com/infinitary"
+        }
+    ],
+    "title": "GDCR18 in Zurich",
+    "url": "https://zurich.codersonly.org/events/code-retreat"
 }

--- a/_data/events_gdcr2018/a-coruña.json
+++ b/_data/events_gdcr2018/a-coruña.json
@@ -1,19 +1,28 @@
 {
-  "title": "Global day of code retreat A Coruña #GDCR18",
-  "url": "https://www.meetup.com/es-ES/Coruna-Agile/events/255764663/",
-  "moderators": [
-    "@borjal",
-    "@dani_latorre",
-    "@pablopr"
-  ],
-  "location": {
-    "city": "A Coruña",
-    "country": "Spain",
-    "coordinates": {
-      "latitude": 43.3618728,
-      "longitude": -8.4301933
+    "location": {
+        "city": "A Coru\u00f1a",
+        "coordinates": {
+            "latitude": 43.3618728,
+            "longitude": -8.4301933
+        },
+        "country": "Spain",
+        "timezone": "Europe/Madrid",
+        "utcOffset": 2
     },
-    "utcOffset": 2,
-    "timezone": "Europe/Madrid"
-  }
+    "moderators": [
+        {
+            "name": "Borja Fdez Pillado",
+            "url": "https://twitter.com/borjal"
+        },
+        {
+            "name": "Dani Latorre",
+            "url": "https://twitter.com/dani_latorre"
+        },
+        {
+            "name": "Pablo Pazos",
+            "url": "https://twitter.com/pablopr"
+        }
+    ],
+    "title": "Global day of code retreat A Coru\u00f1a #GDCR18",
+    "url": "https://www.meetup.com/es-ES/Coruna-Agile/events/255764663/"
 }

--- a/_data/events_gdcr2018/helsinki.json
+++ b/_data/events_gdcr2018/helsinki.json
@@ -1,20 +1,26 @@
 {
-  "title": "GDCR in Helsinki",
-  "url": "https://www.eventbrite.co.uk/e/global-day-of-coderetreat-helsinki-tickets-51246828644",
-  "moderators": [
-    "@rinkkasatiainen"
-  ],
-  "sponsors": [
-    "@ambientia"
-  ],
-  "location": {
-    "city": "Helsinki",
-    "country": "Finland",
-    "coordinates": {
-      "latitude": 60.1098679,
-      "longitude": 24.7385151
+    "location": {
+        "city": "Helsinki",
+        "coordinates": {
+            "latitude": 60.1098679,
+            "longitude": 24.7385151
+        },
+        "country": "Finland",
+        "timezone": "Europe/Helsinki",
+        "utcOffset": 3
     },
-    "utcOffset": 3,
-    "timezone": "Europe/Helsinki"
-  }
+    "moderators": [
+        {
+            "name": "Aki Salmi",
+            "url": "https://twitter.com/rinkkasatiainen"
+        }
+    ],
+    "sponsors": [
+        {
+            "name": "Ambientia",
+            "url": "https://twitter.com/ambientia"
+        }
+    ],
+    "title": "GDCR in Helsinki",
+    "url": "https://www.eventbrite.co.uk/e/global-day-of-coderetreat-helsinki-tickets-51246828644"
 }

--- a/_data/events_gdcr2018/madrid.json
+++ b/_data/events_gdcr2018/madrid.json
@@ -1,23 +1,38 @@
 {
-  "title": "GDCR 18 Madrid",
-  "url": "https://www.meetup.com/madswcraft/events/255270965/",
-  "moderators": [
-    "@finuka",
-    "@keyvanakbary",
-    "@rubendm23",
-    "@juandvegarguez"
-  ],
-  "sponsors": [
-    "@CabifyDev"
-  ],
-  "location": {
-    "city": "Madrid",
-    "country": "Spain",
-    "coordinates": {
-      "latitude": 40.449009,
-      "longitude": -3.670911
+    "location": {
+        "city": "Madrid",
+        "coordinates": {
+            "latitude": 40.449009,
+            "longitude": -3.670911
+        },
+        "country": "Spain",
+        "timezone": "Europe/Berlin",
+        "utcOffset": 2
     },
-    "utcOffset": 2,
-    "timezone": "Europe/Berlin"
-  }
+    "moderators": [
+        {
+            "name": "Josefina P\u00e9rez",
+            "url": "https://twitter.com/finuka"
+        },
+        {
+            "name": "Keyvan Akbary",
+            "url": "https://twitter.com/keyvanakbary"
+        },
+        {
+            "name": "Rub\u00e9n",
+            "url": "https://twitter.com/rubendm23"
+        },
+        {
+            "name": "Juan David Vega",
+            "url": "https://twitter.com/juandvegarguez"
+        }
+    ],
+    "sponsors": [
+        {
+            "name": "Cabify Product Team",
+            "url": "https://twitter.com/CabifyDev"
+        }
+    ],
+    "title": "GDCR 18 Madrid",
+    "url": "https://www.meetup.com/madswcraft/events/255270965/"
 }

--- a/_data/events_gdcr2018/olomouc.json
+++ b/_data/events_gdcr2018/olomouc.json
@@ -1,18 +1,24 @@
 {
-  "title": "GDCR18 - CZE, Olomouc",
-  "url": "http://meetu.ps/e/G0qwt/zBCnJ/f",
-  "moderators": [
-    "@tomaslatal",
-    "@mcbigcz"
-  ],
-  "location": {
-    "city": "Olomouc",
-    "country": "Czech Republic",
-    "coordinates": {
-      "latitude": 49.597897,
-      "longitude": 17.258257
+    "location": {
+        "city": "Olomouc",
+        "coordinates": {
+            "latitude": 49.597897,
+            "longitude": 17.258257
+        },
+        "country": "Czech Republic",
+        "timezone": "Europe/Prague",
+        "utcOffset": 2
     },
-    "utcOffset": 2,
-    "timezone": "Europe/Prague"
-  }
+    "moderators": [
+        {
+            "name": "Tomas Latal",
+            "url": "https://twitter.com/tomaslatal"
+        },
+        {
+            "name": "Dalibor Flori\u00e1n",
+            "url": "https://twitter.com/mcbigcz"
+        }
+    ],
+    "title": "GDCR18 - CZE, Olomouc",
+    "url": "http://meetu.ps/e/G0qwt/zBCnJ/f"
 }

--- a/_data/events_gdcr2018/radford.json
+++ b/_data/events_gdcr2018/radford.json
@@ -1,15 +1,20 @@
 {
-  "title": "NRV Dev 2018 Global Day of Code Retreat",
-  "url": "https://www.eventbrite.com/e/nrv-dev-2018-global-day-of-code-retreat-tickets-51572497729?aff=ebdssbdestsearch",
-  "moderators": ["@kevpo"],
-  "location": {
-      "city": "Radford",
-      "country": "United States of America",
-      "coordinates": {
-      "latitude": 37.1203638,
-      "longitude": -80.5691916
+    "location": {
+        "city": "Radford",
+        "coordinates": {
+            "latitude": 37.1203638,
+            "longitude": -80.5691916
+        },
+        "country": "United States of America",
+        "timezone": "America/New_York",
+        "utcOffset": -4
     },
-    "utcOffset": -4,
-    "timezone": "America/New_York"
-  }
-} 
+    "moderators": [
+        {
+            "name": "\u1d0b\u1d07\u1d20\u026a\u0274 \u1d18\u1d0fs\u1d1b\u1d0f\u0274",
+            "url": "https://twitter.com/kevpo"
+        }
+    ],
+    "title": "NRV Dev 2018 Global Day of Code Retreat",
+    "url": "https://www.eventbrite.com/e/nrv-dev-2018-global-day-of-code-retreat-tickets-51572497729?aff=ebdssbdestsearch"
+}

--- a/_data/events_gdcr2018/southampton.json
+++ b/_data/events_gdcr2018/southampton.json
@@ -1,18 +1,24 @@
 {
-  "title": "GDCR18 Agile South Coast - Whitely, Fareham",
-  "url": "https://www.meetup.com/Agile-South-Coast-Southampton-Chapter/events/255861766/",
-  "moderators": [
-    "@tooky",
-    "@busywait"
-  ],
-  "location": {
-    "city": "Southampton",
-    "country": "United Kingdom",
-    "coordinates": {
-      "latitude": 50.87675,
-      "longitude": -1.243049
+    "location": {
+        "city": "Southampton",
+        "coordinates": {
+            "latitude": 50.87675,
+            "longitude": -1.243049
+        },
+        "country": "United Kingdom",
+        "timezone": "Europe/London",
+        "utcOffset": 1
     },
-    "utcOffset": 1,
-    "timezone": "Europe/London"
-  }
+    "moderators": [
+        {
+            "name": "Steve Tooke",
+            "url": "https://twitter.com/tooky"
+        },
+        {
+            "name": "Steven Mackenzie",
+            "url": "https://twitter.com/busywait"
+        }
+    ],
+    "title": "GDCR18 Agile South Coast - Whitely, Fareham",
+    "url": "https://www.meetup.com/Agile-South-Coast-Southampton-Chapter/events/255861766/"
 }

--- a/_data/events_gdcr2018/toronto.json
+++ b/_data/events_gdcr2018/toronto.json
@@ -1,13 +1,15 @@
 {
-  "title": "GDCR18 in Toronto",
-  "url": "https://gdcr-2018-toronto.eventbrite.ca",
-  "moderators": [
-    "Chris Gow"
-  ],
-  "location": {
-    "city": "Toronto",
-    "country": "Canada",
-    "utcOffset": -4,
-    "timezone": "America/Toronto"
-  }
+    "location": {
+        "city": "Toronto",
+        "country": "Canada",
+        "timezone": "America/Toronto",
+        "utcOffset": -4
+    },
+    "moderators": [
+        {
+            "name": "Chris Gow"
+        }
+    ],
+    "title": "GDCR18 in Toronto",
+    "url": "https://gdcr-2018-toronto.eventbrite.ca"
 }

--- a/_data/events_gdcr2018/virtual_invision.json
+++ b/_data/events_gdcr2018/virtual_invision.json
@@ -1,11 +1,17 @@
 {
-  "title": "Remote GDCR18 (EST)",
-  "url": "https://www.eventbrite.com/e/remote-global-day-of-coderetreat-tickets-52004086623",
-  "moderators": [
-    "@philborlin"
-  ],
-  "sponsors": [
-    "@InVisionApp"
-  ],
-  "location": "virtual"
+    "location": "virtual",
+    "moderators": [
+        {
+            "name": "Philip Borlin",
+            "url": "https://twitter.com/philborlin"
+        }
+    ],
+    "sponsors": [
+        {
+            "name": "InVision",
+            "url": "https://twitter.com/InVisionApp"
+        }
+    ],
+    "title": "Remote GDCR18 (EST)",
+    "url": "https://www.eventbrite.com/e/remote-global-day-of-coderetreat-tickets-52004086623"
 }

--- a/_data/events_gdcr2018/washingtondc.json
+++ b/_data/events_gdcr2018/washingtondc.json
@@ -1,21 +1,30 @@
 {
-  "title": "Global Day of Code Retreat Washington, DC 2018",
-  "url": "https://www.eventbrite.com/e/global-day-of-code-retreat-washington-dc-2018-tickets-50966108001",
-  "moderators": [
-    "@thepatleong",
-    "@sjkilleen"
-  ],
-  "sponsors": [
-    "@ExcellaCo"
-  ],
-  "location": {
-    "city": "Washington, DC",
-    "country": "United States of America",
-    "coordinates": {
-      "latitude": 38.890573,
-      "longitude": -77.087052
+    "location": {
+        "city": "Washington, DC",
+        "coordinates": {
+            "latitude": 38.890573,
+            "longitude": -77.087052
+        },
+        "country": "United States of America",
+        "timezone": "America/New_York",
+        "utcOffset": -4
     },
-    "utcOffset": -4,
-    "timezone": "America/New_York"
-  }
-} 
+    "moderators": [
+        {
+            "name": "Patrick Leong",
+            "url": "https://twitter.com/thepatleong"
+        },
+        {
+            "name": "Sean Killeen",
+            "url": "https://twitter.com/sjkilleen"
+        }
+    ],
+    "sponsors": [
+        {
+            "name": "ExcellaCo",
+            "url": "https://twitter.com/ExcellaCo"
+        }
+    ],
+    "title": "Global Day of Code Retreat Washington, DC 2018",
+    "url": "https://www.eventbrite.com/e/global-day-of-code-retreat-washington-dc-2018-tickets-50966108001"
+}

--- a/events/event_schema.json
+++ b/events/event_schema.json
@@ -16,8 +16,20 @@
     "moderators": {
       "type": "array",
       "items": {
-        "description": "Name or Twitter Handle of the moderators",
-        "type": "string"
+        "description": "List of moderators",
+        "type": "object",
+        "properties": {
+          "name": {
+            "description": "Moderator's name",
+            "type": "string"
+          },
+          "url" : {
+            "description": "Moderator's url: Twitter profile, GitHub profile, website, ...",
+            "type": "string"
+          }
+        },
+        "additionalProperties": false,
+        "required": ["name"]
       }
     },
     "location": {
@@ -29,8 +41,20 @@
     "sponsors": {
       "type": "array",
       "items": {
-        "description": "Name or Twitter Handle of the sponsors",
-        "type": "string"
+        "description": "List of sponsors",
+        "type": "object",
+        "properties": {
+          "name": {
+            "description": "Sponsor's name",
+            "type": "string"
+          },
+          "url" : {
+            "description": "Sponsor's url: Twitter profile, GitHub profile, website, ...",
+            "type": "string"
+          }
+        }, 
+        "additionalProperties": false,
+        "required": ["name"]
       }
     }
   },

--- a/events/index.html
+++ b/events/index.html
@@ -46,33 +46,25 @@ description: List of events around the world!
             {% assign loopCount = event.moderators | size | minus: 1 %}
             {% for i in (0..loopCount) %}
             {% assign moderator = event.moderators[i] %}
-            {% assign first_char = moderator | slice: 0 %}
-            {% if first_char == '@' %}
-            {% assign sizeWithoutAt = moderator | size | minus: 1 %}
-            {% assign handle = moderator | slice: 1, sizeWithoutAt %}
-            <a href="https://twitter.com/{{ handle }}">{{ moderator }}</a>
+            {% if moderator.url %}
+            <a href="{{ moderator.url }}">{{ moderator.name }}</a>{% if i != loopCount %}, {% endif %}
             {% else %}
-            {{ moderator }}
+            {{ moderator.name }}{% if i != loopCount %}, {% endif %}
             {% endif %}
-            {% if i != loopCount %}, {% endif %}
             {% endfor %}
         </td>
 
 
         <td>
-            {%- assign loopCount = event.sponsors | size | minus: 1 -%}
-            {%- for i in (0..loopCount) -%}
-            {%- assign sponsor = event.sponsors[i] -%}
-            {%- assign first_char = sponsor | slice: 0 -%}
-            {%- if first_char == '@' -%}
-            {%- assign sizeWithoutAt = sponsor | size | minus: 1 -%}
-            {%- assign handle = sponsor | slice: 1, sizeWithoutAt -%}
-            <a href="https://twitter.com/{{ handle }}">{{ sponsor }}</a>
-            {%- else -%}
-            {{- sponsor -}}
-            {%- endif -%}
-            {%- if i != loopCount -%}, {%- endif -%}
-            {%- endfor -%}
+            {% assign loopCount = event.sponsors | size | minus: 1 %}
+            {% for i in (0..loopCount) %}
+            {% assign sponsor = event.sponsors[i] %}
+            {% if sponsor.url %}
+            <a href="{{ sponsor.url }}">{{ sponsor.name }}</a>{% if i != loopCount %}, {% endif %}
+            {% else %}
+            {{ sponsor.name }}{% if i != loopCount %}, {% endif %}
+            {% endif %}
+            {% endfor %}
         </td>
 
 
@@ -88,33 +80,25 @@ description: List of events around the world!
             {% assign loopCount = event.moderators | size | minus: 1 %}
             {% for i in (0..loopCount) %}
             {% assign moderator = event.moderators[i] %}
-            {% assign first_char = moderator | slice: 0 %}
-            {% if first_char == '@' %}
-            {% assign sizeWithoutAt = moderator | size | minus: 1 %}
-            {% assign handle = moderator | slice: 1, sizeWithoutAt %}
-            <a href="https://twitter.com/{{ handle }}">{{ moderator }}</a>
+            {% if moderator.url %}
+            <a href="{{ moderator.url }}">{{ moderator.name }}</a>{% if i != loopCount %}, {% endif %}
             {% else %}
-            {{ moderator }}
+            {{ moderator.name }}{% if i != loopCount %}, {% endif %}
             {% endif %}
-            {% if i != loopCount %}, {% endif %}
             {% endfor %}
         </td>
 
 
         <td>
-            {%- assign loopCount = event.sponsors | size | minus: 1 -%}
-            {%- for i in (0..loopCount) -%}
-            {%- assign sponsor = event.sponsors[i] -%}
-            {%- assign first_char = sponsor | slice: 0 -%}
-            {%- if first_char == '@' -%}
-            {%- assign sizeWithoutAt = sponsor | size | minus: 1 -%}
-            {%- assign handle = sponsor | slice: 1, sizeWithoutAt -%}
-            <a href="https://twitter.com/{{ handle }}">{{ sponsor }}</a>
-            {%- else -%}
-            {{- sponsor -}}
-            {%- endif -%}
-            {%- if i != loopCount -%}, {%- endif -%}
-            {%- endfor -%}
+            {% assign loopCount = event.sponsors | size | minus: 1 %}
+            {% for i in (0..loopCount) %}
+            {% assign sponsor = event.sponsors[i] %}
+            {% if sponsor.url %}
+            <a href="{{ sponsor.url }}">{{ sponsor.name }}</a>{% if i != loopCount %}, {% endif %}
+            {% else %}
+            {{ sponsor.name }}{% if i != loopCount %}, {% endif %}
+            {% endif %}
+            {% endfor %}
         </td>
 
 

--- a/scripts/migration/adding_url_to_users.py
+++ b/scripts/migration/adding_url_to_users.py
@@ -1,0 +1,32 @@
+#!/usr/bin/python3
+
+import sys
+import json
+import subprocess
+
+
+event_file = open(sys.argv[1], 'r')
+event_info = json.load(event_file)
+
+
+for key in ['moderators', 'sponsors']:
+    if key not in event_info: continue
+
+    users_list = []
+    for user in event_info[key]:
+        if user[0] != '@':
+            users_list.append({"name": user})
+            continue
+
+        command_line = "/1.1/users/show.json?screen_name=" + user[1:]
+        command_response = subprocess.run(["twurl", command_line], capture_output="True", timeout=20)
+        user_data = json.loads(command_response.stdout)
+        if 'errors' in user_data:
+            users_list.append({"name": user, "url": 'https://twitter.com/' + user[1:]})
+            continue
+
+        users_list.append({"name": user_data['name'], "url": 'https://twitter.com/' + user[1:]})
+        
+    event_info[key] = users_list
+
+print(json.dumps(event_info, indent=4, sort_keys=True))


### PR DESCRIPTION
For having a more "human" list of events, I included the possibility of adding name and url for each moderator and sponsor.

For migrating the current data to the new proposal, I wrote [a small script](https://github.com/coderetreat/coderetreat.org/blob/959edb62fe58f60d57a9351aa63dabb342225d07/scripts/migration/adding_url_to_users.py) to get names from Twitter aliases.

We have a more "human" list of events now and it's not necessary to have a Twitter account. People will be able to indicate any other profile.

Note: in case of error to get the name from the Twitter account (for example, suspended Twitter account), the Twitter alias with the corresponding link is shown.