### PR TITLE
Add message to the organizers explaining why we have two dates this year

### DIFF
--- a/_includes/event-map.html
+++ b/_includes/event-map.html
@@ -1,18 +1,22 @@
 <section id="locations">
-  <h2 class="h2-main-page">Global Day of Coderetreat</h2>
-  <p class="subtitle">November 16th (or 15th), 2019</p>
-  <p class="subtitle">Last year, there have been <a href="/events">{{site.data.events_gdcr2018 | size}} GDCR 2018 events</a> around the world!</p>
+    <h2 class="h2-main-page">Global Day of Coderetreat</h2>
+    <p class="subtitle">November 16th (or 15th), 2019</p>
+    <p>For the 10th anniversary, we will promote events that happen either on Friday, Nov 15th or Saturday, Nov 16th.
+      Traditionally, the Global Day of Coderetreat takes place on Saturdays, but we also want to invite companies to provide paid educational
+        leave for their employees to participate in a coderetreat, as well as open the event to people who can not participate in events over the weekend. </p>
+    <p>As a local event organizer, it is up to you to decide wether to host an event on Friday or Saturday, or even both 🎉.</p>
+    <p class="subtitle">Last year, there have been <a href="/events">{{site.data.events_gdcr2018 | size}} GDCR 2018 events</a> around the world!</p>
 
-  <div id="map">
-    <div id="popup"></div>
-  </div>
+    <div id="map">
+        <div id="popup"></div>
+    </div>
 </section>
 
 <script>
-$(function() {
-  $.get("/events/gdcr2018.json", function(eventsJson) {
-    var gdcrEvents = mapEventsDataToMapFormat(eventsJson);
-    addEventsToMap(gdcrEvents);
-  });
-});
+    $(function() {
+        $.get("/events/gdcr2018.json", function(eventsJson) {
+            var gdcrEvents = mapEventsDataToMapFormat(eventsJson);
+            addEventsToMap(gdcrEvents);
+        });
+    });
 </script>

--- a/_includes/event-map.html
+++ b/_includes/event-map.html
@@ -2,8 +2,7 @@
     <h2 class="h2-main-page">Global Day of Coderetreat</h2>
     <p class="subtitle">November 16th (or 15th), 2019</p>
     <p>For the 10th anniversary, we will promote events that happen either on Friday, Nov 15th or Saturday, Nov 16th.
-      Traditionally, the Global Day of Coderetreat takes place on Saturdays, but we also want to invite companies to provide paid educational
-        leave for their employees to participate in a coderetreat, as well as open the event to people who can not participate in events over the weekend. </p>
+      Traditionally, the Global Day of Coderetreat takes place on Saturdays, but we also want to invite companies to promote educational opportunities for their employees by hosting a public coderetreat on Friday. We further want to open the event to people who can not participate in events over the weekend. </p>
     <p>As a local event organizer, it is up to you to decide wether to host an event on Friday or Saturday, or even both 🎉.</p>
     <p class="subtitle">Last year, there have been <a href="/events">{{site.data.events_gdcr2018 | size}} GDCR 2018 events</a> around the world!</p>
 


### PR DESCRIPTION
As per [Trello Card](https://trello.com/c/O7aiGTQ0/54-explain-the-two-dates-asap), I added an explicit explanation right next to the date.

If this is alright for everyone, I'd merge it and also tweet a similar message so everyone knows what's going on