### PR TITLE
Sponsor

### DIFF
--- a/_data/events_gdcr2019/karlsruhe.json
+++ b/_data/events_gdcr2019/karlsruhe.json
@@ -25,6 +25,12 @@
             "url": "https://twitter.com/petfic"
         }
     ],
+    "sponsors": [
+    {
+        "name": "Fiducia & GAD IT AG",
+        "url": "https://www.fiduciagad.de/"
+    }
+    ],
     "title": "GDCR19 Karlsruhe @fiducia_gad",
     "url": "https://www.softwerkskammer.org/activities/ka-gdcr-19/"
 }

--- a/_data/events_gdcr2019/muenster.json
+++ b/_data/events_gdcr2019/muenster.json
@@ -8,8 +8,8 @@
   ],
   "sponsors": [
     {
-      "name": "Fiducia GAD IT AG",
-      "url": "https://www.fiduciagad.de/startseite.html"
+      "name": "Fiducia & GAD IT AG",
+      "url": "https://www.fiduciagad.de/"
     }
   ],
   "date": {


### PR DESCRIPTION
- Karlsruhe: Fiducia & GAD IT AG added as sponsor
- Münster: sponsor url changed to root, sponsor name changed to official notation