### PR TITLE
Create duesseldorf.json

### DIFF
--- a/_data/events_gdcr2019/duesseldorf.json
+++ b/_data/events_gdcr2019/duesseldorf.json
@@ -1,0 +1,39 @@
+{
+  "title": "GDCR2019 SWK D'dorf Vorwerk",
+  "url": "https://www.meetup.com/de-DE/Softwerkskammer-Dusseldorf/",
+  "moderators": [
+    {
+      "name": "Birgit Kratz",
+      "url": "https://www.xing.com/profile/Birgit_Kratz2"
+    },
+    {
+      "name": "Tim Riemer",
+      "url": "https://twitter.com/zordan_f"
+    },
+    {
+      "name": "Michael Arends"
+    },
+    {
+      "name": "Ulrich Freyer-Hirtz",
+      "url": "https://www.xing.com/profile/Ulrich_FreyerHirtz"
+    }
+  ],
+  "sponsors": [
+    {
+      "name": "Vorwerk GmbH & Co KG",
+      "url": "https://corporate.vorwerk.de/home/"
+    }
+  ],
+  "date": {
+    "start": "2019-11-16T09:00:00.000+01:00",
+    "end": "2019-11-16T17:00:00.000+01:00"
+  },
+  "location": {
+    "city": "Düsseldorf",
+    "country": "Germany",
+    "coordinates": {
+      "latitude": 51.2759026,
+      "longitude": 6.7686522
+    }
+  }
+}


### PR DESCRIPTION
Softwerkskammer Düsseldorf to host the GDCR2019.
Removed doubled link as requested by reviewer.