### PR TITLE
Add event file for GDCR 2019 Cologne @ThoughtWorks

### DIFF
--- a/_data/events_gdcr2019/cologne-thoughtworks.json
+++ b/_data/events_gdcr2019/cologne-thoughtworks.json
@@ -1,0 +1,28 @@
+{
+  "title": "GDCR 2019 Cologne @ThoughtWorks",
+  "url": "https://www.meetup.com/ThoughtWorks_Koeln/events/265679893/",
+  "moderators": [
+    {
+      "name": "Burak Ince",
+      "url": "https://twitter.com/burakinc"
+    }
+  ],
+  "sponsors": [
+    {
+      "name": "ThoughtWorks",
+      "url": "https://www.thoughtworks.com/locations/cologne"
+    }
+  ],
+  "date": {
+    "start": "2019-11-16T09:00:00+01:00",
+    "end": "2019-11-16T18:00:00+01:00"
+  },
+  "location": {
+    "city": "Cologne",
+    "country": "Germany",
+    "coordinates": {
+      "latitude": 50.9480726,
+      "longitude": 6.9066162
+    }
+  }
+}


### PR DESCRIPTION
Global Day of Code Retreat 2019 in the Cologne event. Sponsored by ThoughtWorks. Please approve it.