### PR TITLE
added Gothenburg, Sweden

### DIFF
--- a/_data/events_gdcr2019/gothenburg-fri.json
+++ b/_data/events_gdcr2019/gothenburg-fri.json
@@ -1,0 +1,32 @@
+{
+  "title": "Global Day of Code Retreat Gothenburg @ ProAgile",
+  "url": "https://www.meetup.com/Software-Craftsmanship-Goteborg/events/265895170",
+  "moderators": [
+    {
+      "name": "Emily Bache",
+      "url": "http://coding-is-like-cooking.info/"
+    },
+    {
+      "name": "Fredrik Wendt",
+      "url": "https://proagile.se/blog/medarbetare/fredrik-wendt"
+    }
+  ],
+  "sponsors": [
+    {
+      "name": "ProAgile AB",
+      "url": "https://proagile.se/"
+    }
+  ],
+  "date": {
+    "start": "2019-11-15T08:30:00.000+01:00",
+    "end": "2019-11-15T16:00:00.000+01:00"
+  },
+  "location": {
+    "city": "Göteborg",
+    "country": "Sweden",
+    "coordinates": {
+      "latitude": 57.6892,
+      "longitude": 11.99539
+    }
+  }
+}


### PR DESCRIPTION
Global Day of Code Retreat Gothenburg 2019 hosted by ProAgile. I added a json file for this event.