### PR TITLE
Add Volkswagen Digital:Lab Berlin

### DIFF
--- a/_data/events_gdcr2019/berlin-vw.json
+++ b/_data/events_gdcr2019/berlin-vw.json
@@ -1,0 +1,32 @@
+{
+  "title": "GDCR19 with Volkswagen Digital:Lab and Hexad GmbH",
+  "url": "https://www.eventbrite.com/e/gdcr-2019-berlin-at-volkswagen-digitallab-and-hexad-gmbh-tickets-79690405147",
+  "moderators": [
+    {
+      "name": "Abhimanyu Chakravarty",
+      "url": "https://github.com/achakravarty"
+    }
+  ],
+  "sponsors": [
+    {
+      "name": "Volkswagen Digital:Lab",
+      "url": "https://www.volkswagenag.com/"
+    },
+    {
+      "name": "Hexad GmbH",
+      "url": ""
+    }
+  ],
+  "date": {
+    "start": "2019-11-15T08:00:00.000+01:00",
+    "end": "2019-11-15T17:00:00.000+01:00"
+  },
+  "location": {
+    "city": "Berlin",
+    "country": "Germany",
+    "coordinates": {
+      "latitude": 52.499781,
+      "longitude": 13.455376
+    }
+  }
+}

--- a/_data/events_gdcr2019/berlin-vw.json
+++ b/_data/events_gdcr2019/berlin-vw.json
@@ -14,7 +14,7 @@
     },
     {
       "name": "Hexad GmbH",
-      "url": ""
+      "url": "http://hexad.de/"
     }
   ],
   "date": {


### PR DESCRIPTION
Add event for GDCR Berlin, hosted by Volkswagen Digital:Lab in partnership with Hexad GmbH