### PR TITLE
Add Hexad Berlin

### DIFF
--- a/_data/events_gdcr2019/berlin-hexad.json
+++ b/_data/events_gdcr2019/berlin-hexad.json
@@ -1,0 +1,32 @@
+{
+  "title": "GDCR19 with Hexad GmbH & Volkswagen Digital:Lab",
+  "url": "https://www.eventbrite.com/e/gdcr-2019-berlin-at-volkswagen-digitallab-and-hexad-gmbh-tickets-79690405147",
+  "moderators": [
+    {
+      "name": "Abhimanyu Chakravarty",
+      "url": "https://github.com/achakravarty"
+    }
+  ],
+  "sponsors": [
+    {
+      "name": "Hexad GmbH",
+      "url": "https://hexad.de"
+    },
+    {
+      "name": "Volkswagen Digital:Lab",
+      "url": "https://www.volkswagenag.com/"
+    }
+  ],
+  "date": {
+    "start": "2019-11-16T08:00:00.000+01:00",
+    "end": "2019-11-16T17:00:00.000+01:00"
+  },
+  "location": {
+    "city": "Berlin",
+    "country": "Germany",
+    "coordinates": {
+      "latitude": 52.4995057,
+      "longitude": 13.4540569
+    }
+  }
+}

--- a/_data/events_gdcr2019/berlin-hexad.json
+++ b/_data/events_gdcr2019/berlin-hexad.json
@@ -1,6 +1,6 @@
 {
   "title": "GDCR19 with Hexad GmbH & Volkswagen Digital:Lab",
-  "url": "https://www.eventbrite.com/e/gdcr-2019-berlin-at-volkswagen-digitallab-and-hexad-gmbh-tickets-79690405147",
+  "url": "https://www.meetup.com/Hexad-Technical-Meetups/events/266227351",
   "moderators": [
     {
       "name": "Abhimanyu Chakravarty",


### PR DESCRIPTION
Add event for GDCR Berlin, hosted by Hexad Gmbh in partnership with Volkswagen Digital:Lab