### PR TITLE
fix typo in slack channel name

### DIFF
--- a/hosts/gdcr-tools/embedded.html
+++ b/hosts/gdcr-tools/embedded.html
@@ -40,7 +40,7 @@
           <ul>
              <li>We recommend you stay in your video booth all day long. Even if you only have short chats with other locations (recommended), staying in the video booth will make it a lot easier to coordinate the chats. It is also fun to watch what is happening in the other locations throughout the day.</li>
              <li>Project the video booth all day on a dedicated screen or projector.</li>
-             <li>If no one is in your video booth, then you can use the #gdrc channel set up on the <a href="http://slack.softwarecrafters.org" target="_blank">Software Crafters Slack Community</a> to see if anyone is available and interested to have a quick call.</li>
+             <li>If no one is in your video booth, then you can use the #gdcr channel set up on the <a href="http://slack.softwarecrafters.org" target="_blank">Software Crafters Slack Community</a> to see if anyone is available and interested to have a quick call.</li>
              <li>Use <a href="https://twitter.com/search?q=(%23gdcr19%20AND%20%23live)" target="_blank">Twitter</a> to find locations running their coderetreat around the same time as yours and who may be available for a video chat.</li>
              <li>If there is no one in your video booth, then feel free to join a different video booth...</li>
           </ul>

--- a/pages/facilitating/media-pack.md
+++ b/pages/facilitating/media-pack.md
@@ -20,7 +20,7 @@ Use the same capitalization rules for Coderetreat as you would use for the seaso
 
 ### Fonts
 
-* [Orbitron](http://www.theleagueofmoveabletype.com/fonts/12-orbitron)
+* [Orbitron](https://www.theleagueofmoveabletype.com/orbitron)
     * Suggested usage: Level 1 headers
 * [Amaranth](https://www.google.com/fonts/specimen/Amaranth)
     * Suggested usage: Level 2 Headers


### PR DESCRIPTION
Channel was '#gdrc' changed to '#gdcr'