### PR TITLE
Add experience-as-facilitator 2019 Melbourne

### DIFF
--- a/_data/articles/experiences/as-a-facilitator/2019-Terence-Duong.yaml
+++ b/_data/articles/experiences/as-a-facilitator/2019-Terence-Duong.yaml
@@ -1,0 +1,9 @@
+title: Global Day of Coderetreat - Melbourne 2019
+url: https://medium.com/seek-blog/global-day-of-coderetreat-melbourne-2019-67f300937c9d
+author:
+    name: Terence Duong
+    link: "https://www.linkedin.com/in/terenceduong/"
+year: 2019
+location:
+    city: Melbourne
+    country: Australia


### PR DESCRIPTION
Hello Coderetreaters,

I'm looking to add my article for GDCR Melbourne 2019 into the list of blog entries.
[Find the blog post here!](https://medium.com/seek-blog/global-day-of-coderetreat-melbourne-2019-67f300937c9d)

I was wondering if it would be okay to add the blog entry to both, as guests would only check facilitation or attendee and this entry kind of includes both?

Regards,
Terence.