### PR TITLE
Add Global Day of Coderetreat 2021 - Shinjuku Tokyo

### DIFF
--- a/_data/events/japan-shinagawa-tokyo-2020-11-07-global-day-of-coderetreat-2021.json
+++ b/_data/events/japan-shinagawa-tokyo-2020-11-07-global-day-of-coderetreat-2021.json
@@ -1,0 +1,43 @@
+{
+  "title": "Global Day of Coderetreat 2021 in Shinjuku",
+  "description": "Global Day of Coderetreat 2021 by Shinagawa Agile , Shinjuku, Tokyo.",
+  "format": "ensemble",
+  "spoken_language": "Japanese",
+  "url": "https://connpass.com/event/229635/",
+  "date": {
+    "start": "2021-11-13T09:00:00+09:00",
+    "end": "2021-11-13T17:30:00+09:00"
+  },
+  "moderators": [
+    {
+      "name": "Yattomu",
+      "url": "https://twitter.com/yattom/"
+    },
+    {
+      "name": "Tommy",
+      "url": "https://twitter.com/tommy1969/"
+    }
+  ],
+  "sponsors": [
+    {
+      "name": "アギレルゴコンサルティング株式会社",
+      "url": "https://www.jp.agilergo.com"
+    },
+    {
+      "name": "やっとむ",
+      "url": "https://twitter.com/yattom/"
+    },
+    {
+      "name": "Degino Inc.",
+      "url": "https://www.degino.com/"
+    }
+  ],
+  "location": {
+    "city": "Shinjuku, Tokyo",
+    "country": "Japan",
+    "coordinates": {
+      "latitude": 35.68891184369357,
+      "longitude": 139.69967554232798
+    }
+  }
+}


### PR DESCRIPTION
GDCR2021 in Shinjuku, Tokyo. Please add our event.