### PR TITLE
Add Jetbrains as sponsor for London GDCR @ LSCC

### DIFF
--- a/_data/events/london-2022-global-day-code-retreat-at-lscc.json
+++ b/_data/events/london-2022-global-day-code-retreat-at-lscc.json
@@ -31,6 +31,10 @@
     {
       "name": "Codurance",
       "url": "https://www.codurance.com/"
+    },
+    {
+      "name": "Jetbrains",
+      "url": "https://www.jetbrains.com/"
     }
   ],
   "location": {


### PR DESCRIPTION
Jetbrains have kindly offered to be an additional sponsor :smile: 