### PR TITLE
Add an article on GDCR event in Toronto

### DIFF
--- a/_data/news.yaml
+++ b/_data/news.yaml
@@ -1,3 +1,11 @@
+- title: "Global Day of Coderetreat Toronto 2022: How we scaled coderetreat to 40+ participants"
+  url: https://connected.io/post/global-day-of-coderetreat-toronto-2022/
+  language: English
+  teaser: "'But will it scale?' Who hasn't been asked that before! At least with coderetreat, we found that it scales quite well. Learn how we planned just enough to scale Toronto's Global Day of Coderetreat in 2022 to over 40 participants."
+  author:
+    name: Paul Sobocinski
+    link: https://connected.io/post/author/paul-sobocinski/
+  year: 2022
 - title: Global Day of Code Retreat 2022 in Wrocław
   url: https://blog.michalp.net/posts/scala/gdcr-2022/
   language: English


### PR DESCRIPTION
Here's my write-up about hosting GDCR this year in Toronto. Specifically, it focuses on the planning aspect; hopefully there will be a follow-up which will describe the day of the event and the learnings gained!

A special kudos to all the facilitators who made it happen: @murphykieran @erithmetic @deniseyu @spike01 @amckinnell thank you all, it wouldn't have been possible without your help.