### PR TITLE
Updates link to toronto event-article

### DIFF
--- a/_data/news.yaml
+++ b/_data/news.yaml
@@ -4,7 +4,7 @@
   teaser: "'But will it scale?' Who hasn't been asked that before! At least with coderetreat, we found that it scales quite well. Learn how we planned just enough to scale Toronto's Global Day of Coderetreat in 2022 to over 40 participants."
   author:
     name: Paul Sobocinski
-    link: https://connected.io/post/author/paul-sobocinski/
+    link: https://spikes.sobes.co/p/scaling-global-day-of-coderetreat-toronto
   year: 2022
 - title: Global Day of Code Retreat 2022 in Wrocław
   url: https://blog.michalp.net/posts/scala/gdcr-2022/


### PR DESCRIPTION
This commit fixes the broken link to the Article about Toronto's Global Day of Coderetreat