### PR TITLE
Fix Thoughtworks branding

### DIFF
--- a/_data/events/2023-11-04-global-day-of-coderetreat-thoughtworks-2023-berlin-germany.json
+++ b/_data/events/2023-11-04-global-day-of-coderetreat-thoughtworks-2023-berlin-germany.json
@@ -1,5 +1,5 @@
 {
-  "title": "Global Day of Coderetreat 2023 @ ThoughtWorks Berlin",
+  "title": "Global Day of Coderetreat 2023 @ Thoughtworks Berlin",
   "format": "classic",
   "spoken_language": "English",
   "url": "https://www.meetup.com/de-DE/software-craftsmanship-berlin/events/296598815/",
@@ -15,7 +15,7 @@
   ],
   "sponsors": [
     {
-      "name": "ThoughtWorks",
+      "name": "Thoughtworks",
       "url": "https://thoughtworks.com/"
     }
   ],


### PR DESCRIPTION
They are now spelled with lower-case W