### PR TITLE
uptadet coderetreat-2024-istanbul-turkiye

### DIFF
--- a/_data/2024-11-09-turkiye-istanbul-global-day-of-coderetreat-2024-istanbul-turkiye.json
+++ b/_data/2024-11-09-turkiye-istanbul-global-day-of-coderetreat-2024-istanbul-turkiye.json
@@ -1,0 +1,29 @@
+{
+  "title": "Global Day of Coderetreat 2024 | Istanbul (Turkiye)",
+  "description": "Local event in the context of the Global Day of Coderetreat organized by Java User Group (JUG) Istanbul.",
+  "format": "classic",
+  "spoken_language": "Turkish",
+  "url": "https://www.jugistanbul.org/event-details/global-day-of-coderetreat-2024",
+  "date": {
+    "start": "2024-11-09T09:00:00+03:00",
+    "end": "2024-11-09T16:00:00+03:00"
+  },
+  "moderators": [
+    {
+      "name": "Erkan TEKEL",
+      "url": "https://github.com/erkantekel"
+    },
+    {
+      "name": "Mert KIZILOGLU",
+      "url": "https://github.com/mertkiziloglu"
+    }
+  ],
+  "location": {
+    "city": "Istanbul",
+    "country": "Türkiye",
+    "coordinates": {
+      "latitude": 41.0091982,
+      "longitude": 28.9662187
+    }
+  }
+}


### PR DESCRIPTION
2024-11-09-turkiye-istanbul-global-day-of-coderetreat-2024-istanbul-turkiye