### PR TITLE
Fix event: typo in Chicago GDCR 2024

### DIFF
--- a/_data/events/2024-11-09-united-states-chicago-global-day-of-coderetreat-chicago.json
+++ b/_data/events/2024-11-09-united-states-chicago-global-day-of-coderetreat-chicago.json
@@ -5,8 +5,8 @@
   "spoken_language": "English",
   "url": "https://www.meetup.com/8th-light-university/events/303376516/?utm_medium=referral&utm_campaign=share-btn_savedevents_share_modal&utm_source=link",
   "date": {
-    "start": "2024-11-08T09:00:00-06:00",
-    "end": "2024-11-08T17:00:00-06:00"
+    "start": "2024-11-09T09:00:00-06:00",
+    "end": "2024-11-09T17:00:00-06:00"
   },
   "moderators": [
     {


### PR DESCRIPTION
Confirmed via the event signup page that it is actually happening on Saturday, not Friday as is indicated in the JSON.

@murphykieran heads up!