### PR TITLE
Add Pittsburgh Coderetreat 2023 article from Technical.ly to news.yaml

### DIFF
--- a/_data/news.yaml
+++ b/_data/news.yaml
@@ -1,3 +1,12 @@
+- title: "Code & Supply hosted a Coderetreat focused on pair programming and test-driven development. Here’s what attendees learned"
+  # canonical URL: https://medium.com/leaky-abstractions/c-s-celebrates-ten-years-of-global-day-of-coderetreat-698593549f8a
+  url: https://technical.ly/software-development/code-supply-coderetreat-2023
+  language: English
+  teaser: "The Pittsburgh software community celebrated 12 years of Global Day of Coderetreat this weekend."
+  author:
+    name: Colin Dean
+    link: https://www.linkedin.com/in/colindean/
+  year: 2023
 - title: "Our take on Global Day of Coderetreat 2023"
   url: https://paramount.tech/blog/2023/11/09/our-take-on-global-day-of-coderetreat-2023.html
   language: English


### PR DESCRIPTION
The _commented_ URL is the original post, but Technical.ly picked it up and ran it with my permission. I'd prefer to link to it as the publisher with the larger circulation.